### PR TITLE
Fix/arp

### DIFF
--- a/pig.py
+++ b/pig.py
@@ -593,13 +593,13 @@ class sniff_dhcp(threading.Thread):
                         if opt[0] == 'subnet_mask':
                             subnet=opt[1]
                             break
-                    
+                    mymac = get_if_hwaddr(conf.iface)
                     myip=pkt[BOOTP].yiaddr
                     sip=pkt[BOOTP].siaddr
                     localxid=pkt[BOOTP].xid
                     localm=unpackMAC(pkt[BOOTP].chaddr)
                     myhostname=''.join(random.choice(string.ascii_uppercase + string.digits) for x in range(8))
-                    LOG(type="<--", message= "DHCP_Offer   " + pkt[Ether].src +"\t"+sip + " IP: "+myip+" for MAC=["+pkt[Ether].dst+"]")
+                    LOG(type="<--", message= "DHCP_Offer   " + pkt[Ether].src +"\t"+sip + " IP: "+myip+" for MAC=["+localm+"]")
     
                     if SHOW_DHCPOPTIONS:
                         b = pkt[BOOTP]
@@ -617,7 +617,7 @@ class sniff_dhcp(threading.Thread):
                             else:
                                 LOG(type="DEBUG", message=  "\t\t* %s\t%s"%(o[0],o[1:])  )    
                     
-                    dhcp_req = Ether(src=localm,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid)/DHCP(options=[("message-type","request"),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list","pad"),"end"])
+                    dhcp_req = Ether(src=mymac,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid,flags=0xFFFFFF)/DHCP(options=[("message-type","request"),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list","pad"),"end"])
                     LOG(type="-->", message= "DHCP_Request "+myip)
                     sendPacket(dhcp_req)
                 elif SHOW_LEASE_CONFIRM and pkt[DHCP] and pkt[DHCP].options[0][1] == 5:

--- a/pig.py
+++ b/pig.py
@@ -661,12 +661,9 @@ def main():
     dhcpdos=False 
     p_dhcp_advertise = None # contains dhcp advertise pkt once it is received (base for creating release())
 
-    if DO_ARP: neighbors()
-    sys.exit()
-    
     LOG(type="DEBUG",message="Thread %d - (Sniffer) READY"%len(THREAD_POOL))
     t=sniff_dhcp()
-    #t.start()
+    t.start()
     THREAD_POOL.append(t)
     
     for i in range(THREAD_CNT):
@@ -678,7 +675,7 @@ def main():
     fail_cnt=100
     while dhcpsip==None and fail_cnt>0:
         time.sleep(TIMEOUT['dhcpip'])
-        #LOG(type="?", message= "\t\twaiting for first DHCP Server response")
+        LOG(type="?", message= "\t\twaiting for first DHCP Server response")
         fail_cnt-=1
     
     if fail_cnt==0:


### PR DESCRIPTION
many DHCP servers not responding on Wifi.  After debugging looks like the frame ethernet mac address should be set the the real mac, and the DHCP chaddr can be faked.

This is the same thing VMWare does in bridged mode.  DHCP server will respond to the real IP will an offer.  Works MUCH better than the old method.

>>also ARP neighbor was broken, it needed to be run before IP&Subnet are set globally.  Moved to using interface IP and subnet for range calculation. 
