### PR TITLE
corrected helpmessage (invalid docstring positioning)

### DIFF
--- a/pig.py
+++ b/pig.py
@@ -1,9 +1,5 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from scapy.all import *
-import string, binascii, signal, sys, threading, socket, struct, getopt
-from sys import stdout
-
 """
 enhanced DHCP exhaustion attack.
 
@@ -46,6 +42,11 @@ Options:
     
     -c, --color                    ... enable color output (off)
 """
+
+from scapy.all import *
+import string, binascii, signal, sys, threading, socket, struct, getopt
+from sys import stdout
+
 
 
 class Colors:


### PR DESCRIPTION
Hello !

The -h/--help options return None has the docstring is misplaced in the python file (after the import), reducing it to "None". This patch update the positioning to make these targets work.