### PR TITLE
Add support for python 3 and scapy 2.5.0

### DIFF
--- a/pig.py
+++ b/pig.py
@@ -342,9 +342,7 @@ def calcCIDR(mask):
 
 
 def unpackMAC(binmac):
-    mac = binascii.hexlify(binmac)[0:12]
-    blocks = [mac[x:x+2] for x in xrange(0, len(mac), 2)]
-    return ':'.join(blocks)
+    return str2mac(binmac)
 
 
 ##########################################################

--- a/pig.py
+++ b/pig.py
@@ -500,7 +500,25 @@ class send_dhcp(threading.Thread):
             # Mac OS options order to avoid DHCP fingerprinting
             myoptions = [
                 ("message-type", "discover"),
-                ("param_req_list", chr(1),chr(121),chr(3),chr(6),chr(15),chr(119),chr(252),chr(95),chr(44),chr(46)),
+#                ("param_req_list", chr(1),chr(121),chr(3),chr(6),chr(15),chr(119),chr(252),chr(95),chr(44),chr(46)),
+#### Fix by k4l3b ####
+# Replaced the chr(n) by it's numeric representation.
+# Can be replaced by DHCPRevOptions[] as stated, but not all parameters are defined in scapy
+# For a full list of 'em: https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.xhtml
+#("param_req_list",chr(1),chr(121),chr(3),chr(6),chr(15),chr(119),chr(252),chr(95),chr(44),chr(46)),
+                ('param_req_list',
+1, # Subnet Mask DHCPRevOptions["subnet_mask"][0]
+121, # Classless Satic Route
+3, # Router DHCPRevOptions["router"][0]
+6, # Domain Name Server DHCPRevOptions["name_server"][0]
+15, # Domain Name DHCPRevOptions["domain"][0]
+119, # Domain Seach
+252, # Private/Proxy Autodiscovery
+95, # LDAP
+44, # NetBIOS over TCP/IP Name Server DHCPRevOptions["NetBIOS_server"][0]
+46 # NetBIOS over TCP/IP Node Type
+),
+#### End of Fix ######
                 ("max_dhcp_size",1500),
                 ("client_id", chr(1), mac2str(m)),
                 ("lease_time",10000),
@@ -606,6 +624,15 @@ class sniff_dhcp(threading.Thread):
                                 LOG(type="DEBUG", message=  "\t\t* %s\t%s"%(o[0],o[1:])  )    
                     
                     dhcp_req = Ether(src=mymac,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid,flags=0xFFFFFF)/DHCP(options=[("message-type","request"),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list","pad"),"end"])
+
+
+#### Fix by k4l3b ####
+# replaced ("param_req_list","pad") with ("param_req_list",0)
+# The '0' is the equivalent of using DHCPRevOptions["pad"][0]
+#dhcp_req = Ether(src=mymac,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid,flags=0xFFFFFF)/DHCP(options=[("message-type","request"),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list","pad"),"end"])
+                    dhcp_req = Ether(src=mymac,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid,flags=0xFFFFFF)/DHCP(options=[("message-type","request"),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list",0),"end"])
+#### End of Fix ######
+
                     LOG(type="-->", message= "DHCP_Request "+myip)
                     sendPacket(dhcp_req)
                 elif SHOW_LEASE_CONFIRM and pkt[DHCP] and pkt[DHCP].options[0][1] == 5:

--- a/pig.py
+++ b/pig.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 enhanced DHCP exhaustion attack.
@@ -156,9 +156,9 @@ def checkArgs():
                                                                       "neighbors-attack-release", "neighbors-attack-garp",
                                                                       "fuzz","ipv6","client-src=","color","v6-rapid-commit",
                                                                       "verbosity=","threads=", "show-lease-confirm","request-options="])
-    except getopt.GetoptError, err:
+    except getopt.GetoptError as err:
         # print help information and exit:
-        print str(err)  # will print something like "option -a not recognized"
+        print(str(err))  # will print something like "option -a not recognized"
         usage()
         sys.exit(2)
     for o,a in opts:
@@ -209,7 +209,7 @@ def checkArgs():
                     if len(x) == 2:
                         REQUEST_OPTS += range(int(x[0]),int(x[1]))
                     else:
-                        print "Error in option - request-options"
+                        print("Error in option - request-options")
                         usage()
                         exit()
                 else:
@@ -227,7 +227,7 @@ def checkArgs():
         sys.exit(2)
         
     if conf.verb:
-        print """---------------------[OPTIONS]-----------
+        print("""---------------------[OPTIONS]-----------
         IPv6                            %s
         fuzz                            %s
 
@@ -252,7 +252,7 @@ def checkArgs():
 -----------------------------------------
         """%(MODE_IPv6, MODE_FUZZ, SHOW_ARP, SHOW_ICMP, SHOW_DHCPOPTIONS, SHOW_LEASE_CONFIRM, repr(REQUEST_OPTS),
              TIMEOUT['timer'], TIMEOUT['dos'], TIMEOUT['dhcpip'],
-             DO_GARP, DO_RELEASE, DO_ARP, repr(MAC_LIST), DO_COLOR)
+             DO_GARP, DO_RELEASE, DO_ARP, repr(MAC_LIST), DO_COLOR))
 
 
 def LOG(message=None, type=None):
@@ -310,21 +310,21 @@ def toNum(ip):
 
 def get_if_net(iff):
     for net, msk, gw, iface, addr in read_routes():
-        if (iff == iface and net != 0L):
+        if (iff == iface and net != 0):
             return ltoa(net)
     warning("No net address found for iface %s\n" % iff)
 
 
 def get_if_msk(iff):
     for net, msk, gw, iface, addr in read_routes():
-        if (iff == iface and net != 0L):
+        if (iff == iface and net != 0):
             return ltoa(msk)
     warning("No net address found for iface %s\n" % iff)
 
 
 def get_if_ip(iff):
     for net, msk, gw, iface, addr in read_routes():
-        if (iff == iface and net != 0L):
+        if (iff == iface and net != 0):
             return addr
     warning("No net address found for iface %s\n" % iff)
 
@@ -685,8 +685,8 @@ def main():
     LOG(type="NOTICE", message= "[DONE] DHCP pool exhausted!")
   
 def usage():
-    print __doc__
+    print(__doc__)
     
 if __name__ == '__main__':
     main()
-    print "\n"
+    print("\n")

--- a/pig.py
+++ b/pig.py
@@ -309,21 +309,21 @@ def toNum(ip):
 
 
 def get_if_net(iff):
-    for net, msk, gw, iface, addr in read_routes():
+    for net, msk, gw, iface, addr, metric in read_routes():
         if (iff == iface and net != 0):
             return ltoa(net)
     warning("No net address found for iface %s\n" % iff)
 
 
 def get_if_msk(iff):
-    for net, msk, gw, iface, addr in read_routes():
+    for net, msk, gw, iface, addr, metric in read_routes():
         if (iff == iface and net != 0):
             return ltoa(msk)
     warning("No net address found for iface %s\n" % iff)
 
 
 def get_if_ip(iff):
-    for net, msk, gw, iface, addr in read_routes():
+    for net, msk, gw, iface, addr, metric in read_routes():
         if (iff == iface and net != 0):
             return addr
     warning("No net address found for iface %s\n" % iff)


### PR DESCRIPTION
Hi, I'm packaging dhcpig (mostly Q&A) for the new debian release and I've found some problems. Basically it wasn't working with newer scapy versions.

I've also had some help from Philippe (who ported it to python 3) and maniaque (who fixed some problems).

I did test it in my network and it seems to be working (it exausthed my dhcp server offerings). But I think more testing is needed to assure everything is working.

Oh, this fixes #17.