### PR TITLE
Bugfix: Invalid server identifier on REQUEST

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ USAGE
 	    -1, --v6-rapid-commit          ... enable RapidCommit (2way ip assignment instead of 4way) (off)
 	    
 	    -s, --client-src               ... a list of client macs 00:11:22:33:44:55,00:11:22:33:44:56 (Default: <random>)
+    	-S, --ethernet-mac             ... Use identical MAC addresses on the Ethernet frame and DHCP frame (off)
 	    -O, --request-options          ... option-codes to request e.g. 21,22,23 or 12,14-19,23 (Default: 0-80)
 	    
 	    -f, --fuzz                     ... randomly fuzz packets (off)

--- a/pig.py
+++ b/pig.py
@@ -21,7 +21,7 @@ Options:
     -1, --v6-rapid-commit          ... enable RapidCommit (2way ip assignment instead of 4way) (off)
     
     -s, --client-src               ... a list of client macs 00:11:22:33:44:55,00:11:22:33:44:56 (Default: <random>)
-    -S, --ethernet-mac             ... Use identical MAC addresses on the Ethernet framd and DHCP frame (off)
+    -S, --ethernet-mac             ... Use identical MAC addresses on the Ethernet frame and DHCP frame (off)
     -O, --request-options          ... option-codes to request e.g. 21,22,23 or 12,14-19,23 (Default: 0-80)
     
     -f, --fuzz                     ... randomly fuzz packets (off)


### PR DESCRIPTION
Thank you very much for maintaining DHCPig. It is a very practical tool and I hope that I can contribute something to the project with this PR.

I came across an issue with DHCPig, where DHCP REQUEST packets were not confirmed with an ACK and instead rejected with a NAK packet.

DHCPig uses the `siaddr` from the BOOTP part of the OFFER packet as the server identifier (DHCP option 54) in the REQUEST packet. However, the investigated device did not write their IP address into the `siaddr` field and instead left the field empty. The DHCP server rejects the REQUEST packet, because the server identifier option is not set.

Changes:

- Adds a new helper function that returns the server identifier from the DHCP option. If option 54 is not defined, the function falls back to the value of `siaddr`.
- Fixes a minor typo in the CLI argument description.
- Adds documentation of CLI argument `-S` to README.md

Testing:

- Tested script functionality on two home router devices from different producers.
  - Router 1 does not set a value for `siaddr`.
  - Router 2 does set a value.
