### PR TITLE
Minor bug fix which causes NACK

### DIFF
--- a/pig.py
+++ b/pig.py
@@ -637,7 +637,7 @@ class sniff_dhcp(threading.Thread):
 
                     # ("param_req_list",0) is the equivalent of using DHCPRevOptions["pad"][0]
                     client_id_bytes = b'\x01' + mac2str(localm)
-                    dhcp_req = Ether(src=mymac,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid,flags=0x0000)/DHCP(options=[("message-type","request"),("client_id",client_id_bytes),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list",0),"end"])
+                    dhcp_req = Ether(src=mymac,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid,flags=0x8000)/DHCP(options=[("message-type","request"),("client_id",client_id_bytes),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list",0),"end"])
                     
                     LOG(type="-->", message= "DHCP_Request "+myip)
                     sendPacket(dhcp_req)

--- a/pig.py
+++ b/pig.py
@@ -611,7 +611,7 @@ class sniff_dhcp(threading.Thread):
                     myip=pkt[BOOTP].yiaddr
                     sip=self.get_server_identifier(pkt[BOOTP].siaddr, pkt[DHCP].options)
                     localxid=pkt[BOOTP].xid
-                    localm=unpackMAC(pkt[BOOTP].chaddr)
+                    localm=str2mac(pkt[BOOTP].chaddr[:6])
                     if ETHERNET_MAC:
                         mymac = localm
                     else:
@@ -636,7 +636,8 @@ class sniff_dhcp(threading.Thread):
                                 LOG(type="DEBUG", message=  "\t\t* %s\t%s"%(o[0],o[1:])  )    
 
                     # ("param_req_list",0) is the equivalent of using DHCPRevOptions["pad"][0]
-                    dhcp_req = Ether(src=mymac,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid,flags=0x8000)/DHCP(options=[("message-type","request"),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list",0),"end"])
+                    client_id_bytes = b'\x01' + mac2str(localm)
+                    dhcp_req = Ether(src=mymac,dst="ff:ff:ff:ff:ff:ff")/IP(src="0.0.0.0",dst="255.255.255.255")/UDP(sport=68,dport=67)/BOOTP(chaddr=[mac2str(localm)],xid=localxid,flags=0x0000)/DHCP(options=[("message-type","request"),("client_id",client_id_bytes),("server_id",sip),("requested_addr",myip),("hostname",myhostname),("param_req_list",0),"end"])
                     
                     LOG(type="-->", message= "DHCP_Request "+myip)
                     sendPacket(dhcp_req)


### PR DESCRIPTION
While testing it in gns3, the dhcp request wouldn't ack;
I've added option 61 so it would look something like this

```
   Option: (61) Client identifier
        Length: 7
        Hardware type: Ethernet (0x01)
        Client MAC address: de:ad:1c:12:c0:ff (de:ad:1c:12:c0:ff)
```
