### PR TITLE
core: harden the exhaustion verdict against lost packets and stale measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 2.7.3 — 2026-08-09
+
+Nine fixes to the exhaustion verdict path, from a penetration-testing review of `exhaust`. Each
+one either stopped the tool from reporting a wrong verdict or removed something that misled the
+operator.
+
+- **Deleted `SERVER_STOPPED_SERVING_TEST_CLIENTS`, a finding that could never fire.** Its
+  condition required `self.state == EXHAUSTED` while `post_new.success` was true, but `state`
+  only ever becomes `EXHAUSTED` when `post_new` is *denied* — the condition was unsatisfiable
+  outside its own test, which faked the state by hand. The distinction it was reaching for is
+  already carried by `DHCP_STARVATION_NOT_ATTAINED` with `reason="control_fired"`.
+- **The control transaction now retransmits (`SessionConfig.control_attempts`, default 3).** The
+  exhaustion verdict was previously derived from a single DISCOVER/OFFER/REQUEST/ACK exchange
+  with no retry — one lost UDP packet could flip a clean network to a false
+  `DHCP_STARVATION_ATTAINED`, or flip a genuinely exhausted one to a false
+  `NEW_CLIENT_BLOCKED_AT_BASELINE`. Retried only on "nothing came back"; a NAK is a definite
+  answer and stops immediately. `ControlOutcome.attempts` and `post_new_attempts` evidence make
+  the retry count auditable in the report.
+- **Fixed `timeout_storm` firing on a successful pool drain.** It used to count every expired
+  in-flight handshake rather than reap *cycles*, so a full window (up to 64) expiring together
+  the moment the pool emptied read as "N consecutive timeouts" and halted in ~2s — well before
+  `offer_silence`'s 10s could report the drain correctly. It no longer accumulates once offers
+  have already ceased, which is `offer_silence`'s job.
+- **A foreign OFFER no longer resets the exhaustion clock.** `_handle_offer()`'s counters
+  (`offers`, `_offers_seen_any`, `_last_offer_ts` — what `offer_silence` reads) were incremented
+  before the ownership check, so any other client's routine DHCP churn on the promiscuous BPF
+  kept `offer_silence` from ever firing on a busy segment. Split into a passive half (server
+  registry, pool estimate — safe from anyone's packet) and an owned half (the exhaustion
+  counters, the REQUEST leg), gated by ownership between them.
+- **Pool-size estimate no longer trusts the subnet mask alone.** A real DHCP scope is usually a
+  slice of its subnet; the mask-based estimate overestimated it, which made
+  `pool_headroom_remaining` the reflexive explanation for any non-result. Added
+  `source="observed_span"`: a measured lower bound from the min/max address actually seen
+  offered (≥8 samples), preferred over the mask guess and explicitly excluded from
+  `POOL_HEADROOM_LOW`'s utilization check (a lower bound would read artificially high there).
+- **Runs now report leases that expired mid-run.** On a short-lease network a long exhaust could
+  lose its own early leases without anything in the report saying so, making a later successful
+  control read as unexplained headroom. New `_leases_expired()` / `leases_expired_during_run`
+  evidence on both `DHCP_STARVATION_*` findings and the RUN_SUMMARY drain step.
+- **The pre-run ARP sweep no longer silently truncates past 1024 hosts per CIDR.** Wider than a
+  /22 used to report a partial host list as if it were the whole segment with no indication.
+  `_sweep_targets()` now returns how many addresses it skipped; surfaced in the "ARP inventory"
+  step and `NEIGHBORS_OBSERVED`'s evidence.
+- **`--request-option` now actually changes the DHCP option-55 content sent.** It was accepted by
+  both `exhaust` and (via `SessionConfig.request_options`) `active-scan`'s INFORM builder, but
+  neither packet builder read the value — every DISCOVER/INFORM always sent the built-in
+  macOS-order list regardless of the flag. Also added to `active-scan`'s CLI, the mode that was
+  already plumbed to receive it. The control transaction's own DISCOVER is deliberately exempt —
+  it must stay a vanilla client, since it's the baseline the verdict is measured against.
+- **Fixed:** the CLI described `exhaust` as `(non-destructive)`. It is the most destructive mode
+  in the tool — it releases every ARP-discovered neighbour's lease, floods the pool, and
+  ARP-evicts hosts off addresses it took. The README and design doc already said so correctly;
+  only `--help` was wrong.
+
 ## 2.7.2 — 2026-08-02
 
 - **Fixed `debian-package`'s `publish` job, which had never actually published anything.**

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ CLI
 | `--no-evict` | skip the ARP-conflict phase |
 | `--report FILE` | write a session report to `FILE` when the run ends; format follows `FILE`'s extension (`.json`/`.csv`/`.html`, default JSON) |
 | `--client-mac MAC` | `exhaust` only; use this MAC instead of a random one (repeatable — rotates through the list) |
-| `--request-option SPEC` | `exhaust` only; DHCP options to request, e.g. `12,14-19,23` (default: 0-79) |
+| `--request-option SPEC` | `exhaust`/`active-scan`; DHCP option-55 (parameter-request-list) content to send, e.g. `12,14-19,23` (default: the built-in macOS-order profile) |
 | `--no-spoof-eth-src` | `exhaust` only; use the real NIC MAC as the Ethernet source for every frame (Wi-Fi; APs drop frames whose source MAC isn't the associated station) |
 
 `-v0` prints results only; `-v3` adds packet-level debug. Full flag reference: `man dhcpig`

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -303,11 +303,21 @@ Three pieces, run in `_common_prelude()` order (shared by both `exhaust` and `re
    `RateLimiter` globally.**
 3. **Halt-on-control** (`_trigger_halt`, `ControlDetected`, `HALTED` state). On the first of five
    signals — `nak_burst` (≥3/5s), `offer_silence` (existing), `link_down` (carrier poll in
-   `_status_ticker`, `netutils.link_is_up()`), `timeout_storm` (≥5 consecutive), `duplicate_offers`
-   (≥3 addresses offered to two of our MACs) — sending stops immediately but **leases already
-   held are kept**, and `stop()` still runs both post-controls so the report is complete. First
-   signal wins (`self._halt_signal` is set once). Don't make halt release leases or skip the
-   post-control — that would break the verdict (§5d).
+   `_status_ticker`, `netutils.link_is_up()`), `timeout_storm` (≥5 stalled reap cycles),
+   `duplicate_offers` (≥3 addresses offered to two of our MACs) — sending stops immediately but
+   **leases already held are kept**, and `stop()` still runs both post-controls so the report is
+   complete. First signal wins (`self._halt_signal` is set once). Don't make halt release leases
+   or skip the post-control — that would break the verdict (§5d).
+   **`timeout_storm` means "handshakes are not completing while the server is still answering
+   someone" — not "the pool just drained."** `_reap_timeouts()`'s `_stalled_reaps` counts *reap
+   cycles that expired something* (2.7.3; was expired-xid count, which let one window's worth of
+   in-flight handshakes — up to `window_max` — expiring together in a single reap read as "N
+   consecutive timeouts" and halt in ~2s), and it does **not** accumulate once
+   `_offers_seen_any` is true and the silence already exceeds `timeouts.dhcp_request` — at that
+   point `offer_silence` (10s by default) is the signal that owns "the pool is drained", and
+   without the guard `timeout_storm` wins that race on every clean drain, so a successful
+   exhaustion gets reported as a defensive control firing instead. Don't let `timeout_storm`
+   accumulate through an already-quiet period again.
 
 ## 5d. Verdict: DHCP_STARVATION_ATTAINED / _NOT_ATTAINED
 - **`DHCP_STARVATION_ATTAINED`** (`FAIL`): `acks > 0` **and** the post-run **new-MAC** control
@@ -320,12 +330,31 @@ Three pieces, run in `_common_prelude()` order (shared by both `exhaust` and `re
   `ATTAINED` is rare by construction on a defended network** — `NOT_ATTAINED + control_fired`
   naming the control and the lease count it fired at is the expected, actionable result, not a
   consolation prize.
+- **There is no separate "server throttled our test clients" finding.** One existed
+  (`SERVER_STOPPED_SERVING_TEST_CLIENTS`, removed 2.7.3) but its condition — `post_new.success`
+  while `self.state == EXHAUSTED` — could never be true: `state` only becomes `EXHAUSTED` in
+  `stop()` when `post_new` is *denied* (§3), so the finding never fired outside its own test,
+  which faked the state by hand. The distinction it was reaching for — "the server stopped
+  answering *our* test clients while a real client is still served" — is already carried by
+  `DHCP_STARVATION_NOT_ATTAINED` with `reason="control_fired"` plus the named halt signal (§5c).
+  Don't re-add a variant of it without wiring it through an actually-reachable state.
 - **Pool estimate / headroom** (`PoolEstimate`, `_estimate_pool()`, `_pool_headroom()`): resolved
-  from an explicit `--scope` (deterministic host count) or, failing that, the first OFFER's
-  subnet (option 1) via `_note_offer_for_pool_estimate()`. `size=None` when neither is known —
+  in order — an explicit `--scope` (deterministic host count); else an **observed span**
+  (`source="observed_span"`, 2.7.3): the min/max of every address seen offered inside the
+  first-known subnet, folded in by `_note_offer_for_pool_estimate()` from *any* OFFER on the
+  segment (task 4's passive/owned split means this runs for a stranger's OFFER too — an address
+  someone else was offered is still proof the scope contains it); else the first OFFER's subnet
+  wholesale (option 1, `source="observed"`). `size=None` when nothing is known —
   **never fabricate a denominator**; every surface (status, StatusTick, CLI line, web counter,
-  report) must show `source`/`detail` alongside the number. `POOL_HEADROOM_LOW` is a separate,
-  independent finding raised when the *pre-test* ARP baseline already shows ≥80% utilization.
+  report) must show `source`/`detail` alongside the number. `observed_span` exists because a real
+  DHCP scope is usually a *slice* of its subnet (`.100`–`.200` in a /24, say) — the subnet-mask
+  estimate overestimates, which used to make `pool_headroom_remaining` the reflexive explanation
+  for any non-result. It needs `_POOL_SPAN_MIN_SAMPLES` (8) distinct addresses before it's used,
+  so a two-offer run can't be mistaken for a tiny pool, and it is **explicitly excluded** from
+  `POOL_HEADROOM_LOW`'s utilization check (below) — it's a lower bound, so utilization against it
+  reads artificially high and would manufacture the finding. `POOL_HEADROOM_LOW` is a separate,
+  independent finding raised when the *pre-test* ARP baseline already shows ≥80% utilization
+  against a `scope` or `observed` (never `observed_span`) denominator.
 
 ## 5e. Lease journal + `release-previous`
 `restore()` only releases leases the *currently running* engine object acquired, from memory —
@@ -612,6 +641,15 @@ See `CONTRIBUTING.md` for the commands. Two things worth knowing at the design l
   should still passively learn from foreign traffic where safe (server identity, fingerprints,
   marking a tracked foreign DISCOVER as answered) — the risk is on the *send/mutate* side, not
   observation. See §5g's closing bullet for the two real bugs this pattern was written to prevent.
+  **The ownership gate protects measurement, not just sending (2.7.3).** `_handle_offer()` used
+  to bump `self.offers`/`_offers_seen_any`/`_last_offer_ts` — the counters `offer_silence` (§5c)
+  reads to decide the pool has gone quiet — *before* checking `ours`, so any foreign OFFER on the
+  promiscuous BPF (another client's routine DHCP churn, a second scope on the segment) reset the
+  exhaustion clock and made `offer_silence` effectively unreachable on a busy segment. It is now
+  split into a passive half (server registry, the pool-size estimate, marking a tracked foreign
+  DISCOVER answered — all facts about the network, safe from anyone's packet) and an owned half
+  (the exhaustion counters and the REQUEST leg), with the ownership check between them. Any new
+  per-packet counter that feeds a halt signal or a verdict belongs in the owned half.
 - **JSON serialization**: always route event/report dicts through `jsonable()` — a raw `IPVersion`
   enum will crash `json.dumps`. Regression test exists.
 - **Ethernet source MAC** defaults to the per-client random MAC (`spoof_ethernet_src=True`) so

--- a/src/dhcpig/cli/main.py
+++ b/src/dhcpig/cli/main.py
@@ -70,7 +70,13 @@ def build_parser() -> argparse.ArgumentParser:
             help="periodic status line with running stats (default 5s; 0 disables)",
         )
 
-    ex = sub.add_parser("exhaust", help="consume the DHCP pool (non-destructive)")
+    ex = sub.add_parser(
+        "exhaust",
+        help=(
+            "drain the DHCP pool; releases and re-takes neighbours' leases, then "
+            "ARP-evicts (DESTRUCTIVE)"
+        ),
+    )
     common(ex)
     ex.add_argument("--request-option", default=None, help="e.g. 12,14-19,23")
     ex.add_argument("--client-mac", action="append", dest="client_macs")
@@ -140,6 +146,7 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="CIDR",
         help="network(s) to sweep; defaults to the interface's own network",
     )
+    asc.add_argument("--request-option", default=None, help="e.g. 12,14-19,23")
     asc.add_argument("--rate", type=int, default=7)
     asc.add_argument("--dry-run", action="store_true")
     asc.add_argument(
@@ -225,7 +232,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 def build_config(args) -> SessionConfig:
     mode = _MODE_BY_CMD[args.command]
-    req_opts = list(range(80))
+    # None means "use the built-in macOS-order profile" (packets._MACOS_PRL) -- see
+    # SessionConfig.request_options.
+    req_opts = None
     if getattr(args, "request_option", None):
         req_opts = parse_request_options(args.request_option)
     scope = getattr(args, "scope_cidrs", None)

--- a/src/dhcpig/core/engine.py
+++ b/src/dhcpig/core/engine.py
@@ -63,6 +63,11 @@ IDLE, RUNNING, HALTED, EXHAUSTED, STOPPING, DONE = (
     "DONE",
 )
 
+# Per-CIDR cap on how many hosts one ARP sweep probes (§5, blast-radius note). Beyond a /22 this
+# silently truncates the inventory -- see _sweep_targets()'s `skipped` return value, surfaced via
+# _baseline_arp_scan()'s Debug and the RUN_SUMMARY "ARP inventory" step, for how that's reported.
+ARP_SWEEP_MAX_TARGETS = 1024
+
 
 class DhcpEngine:
     def __init__(self, cfg: SessionConfig, bus: EventBus) -> None:
@@ -142,7 +147,10 @@ class DhcpEngine:
         self._inflight: dict[int, dict] = {}
         self._inflight_lock = threading.Lock()
         self.timeouts_seen = 0
-        self._consecutive_timeouts = 0
+        # reap cycles in a row that expired something while offers were still flowing -- see
+        # _reap_timeouts()'s docstring for why this is reap cycles, not expired xids, and why it
+        # doesn't accumulate once offers have already ceased.
+        self._stalled_reaps = 0
         self._nak_timestamps: list[float] = []
         self._offered_ip_macs: dict[str, set[str]] = {}
         self._duplicate_offer_ips: set[str] = set()
@@ -161,7 +169,18 @@ class DhcpEngine:
         # confused with the live _neighbors_by_mac count, which the estimate/headroom uses.
         self._first_offer_ip: str | None = None
         self._first_offer_subnet: str | None = None
+        # observed lower bound on the pool (2.7.3): min/max of every address offered inside the
+        # first-known subnet, folded in by _note_offer_for_pool_estimate(). A real scope is
+        # usually a slice of the subnet (e.g. .100-.200 in a /24), so the subnet-mask estimate
+        # above overestimates -- this is direct evidence instead of a guess. See _estimate_pool().
+        self._pool_lo: int | None = None
+        self._pool_hi: int | None = None
+        self._pool_seen = 0
         self._baseline_neighbor_count = 0
+        # how many addresses the pre-run ARP sweep left unprobed past ARP_SWEEP_MAX_TARGETS --
+        # surfaced in RUN_SUMMARY's "ARP inventory" step so a wide scope doesn't silently report
+        # a partial host list as if it were the whole segment (§5, §7).
+        self._sweep_skipped = 0
         # dry-run only: neighbor count the release phase would have released, for DRY_RUN_SUMMARY
         self._dry_run_would_release = 0
         # exhaust only: (mac, ip) freed by the release phase, held until the sender has
@@ -507,8 +526,62 @@ class DhcpEngine:
         """
         return "02:" + ":".join(f"{random.randint(0, 255):02x}" for _ in range(5))
 
+    def _control_attempt(self, phase: str, client: str, mac: str, xid: int) -> ControlOutcome:
+        """One DISCOVER -> OFFER -> REQUEST -> ACK -> RELEASE cycle, released immediately.
+
+        One retransmission attempt of the logical transaction `_control_transaction()` manages.
+        Same `mac`/`xid` across attempts -- this is one transaction being retransmitted, per RFC
+        2131, not a new one each time, so a reply to an earlier attempt that arrives late during
+        a later one is still correctly consumed by `_consume_control()`.
+        """
+        out = ControlOutcome(phase=phase, client=client, mac=mac, attempted=True)
+        with self._control_lock:
+            self._control_offer = None
+            self._control_ack = None
+            self._control_nak = False
+        self._control_offer_evt.clear()
+        self._control_ack_evt.clear()
+        # No request_options here, deliberately: the control leg must stay a vanilla, unmodified
+        # client, since it's the baseline the verdict (§5a/§5d) is measured against -- customize
+        # the flood's profile via cfg.request_options, never this one.
+        self._send(packets.build_discover_v4(mac, xid, mac), probe=True)
+        who = "real NIC MAC" if client == "self" else "fresh unseen MAC"
+        self._debug(f"CONTROL[{phase}/{client}] DISCOVER xid=0x{xid:08x} chaddr={mac} ({who})")
+        if not self._control_offer_evt.wait(self.cfg.timeouts.control):
+            out.reason = "no OFFER within timeout"
+            return out
+        if self._control_nak:
+            out.reason = "server replied NAK"
+            return out
+        offer = self._control_offer
+        sid, server_mac, offered_ip, subnet = packets.parse_offer(offer)
+        out.offered_ip, out.server_id, out.subnet = offered_ip, sid, subnet
+        out.server_mac = server_mac or None
+        self._note_offer_for_pool_estimate(offered_ip, subnet)
+        lt = packets.dhcp_option(offer[DHCP].options, "lease_time")
+        out.lease_time = int(lt) if isinstance(lt, int) else None
+        self._debug(f"CONTROL[{phase}/{client}] OFFER {offered_ip} from {sid} subnet={subnet}")
+        self._send(packets.build_request_v4(offer, mac), probe=True)
+        self.requests_sent += 1
+        if not self._control_ack_evt.wait(self.cfg.timeouts.control):
+            out.reason = f"OFFER {offered_ip} but no ACK within timeout"
+            return out
+        if self._control_nak:
+            out.reason = f"OFFER {offered_ip} then NAK"
+            return out
+        out.success = True
+        self._debug(f"CONTROL[{phase}/{client}] ACK {offered_ip} — this client can obtain a lease")
+        # give the address straight back; the control must not consume pool capacity
+        self._send(
+            packets.build_release_v4(mac, offered_ip, sid, xid, server_mac=server_mac),
+            probe=True,
+        )
+        self._debug(f"CONTROL[{phase}/{client}] RELEASE {offered_ip}")
+        return out
+
     def _control_transaction(self, phase: str, client: str = "self") -> ControlOutcome:
-        """One legitimate DHCP cycle (DISCOVER/OFFER/REQUEST/ACK/RELEASE), released immediately.
+        """One legitimate DHCP cycle, retried up to `cfg.control_attempts` times, released
+        immediately on success.
 
         Two client identities, because they answer different questions:
           * `self` — this machine's real NIC MAC. The server most likely already has a binding
@@ -516,10 +589,16 @@ class DhcpEngine:
             the right VLAN, but it can succeed even when the free pool is completely drained.
           * `new` — a MAC the server has never seen, which must come off the free list. This is
             the only leg that can show whether a *new* client can still obtain an address.
+
+        The verdict (§5a/§5d) is derived from a single control leg's outcome, so one lost UDP
+        packet used to be able to flip it: a dropped post/new OFFER read as a false
+        DHCP_STARVATION_ATTAINED, a dropped pre/new OFFER read as a false
+        NEW_CLIENT_BLOCKED_AT_BASELINE. Retransmission (2.7.3) is what makes a single exchange
+        trustworthy enough to hang a verdict on -- only retried on "nothing came back" (no OFFER,
+        no ACK); a NAK is a definite answer and stops immediately, same as success does.
         """
-        out = ControlOutcome(phase=phase, client=client)
         if self.cfg.offline:
-            out.reason = "skipped (offline)"
+            out = ControlOutcome(phase=phase, client=client, reason="skipped (offline)")
             self.bus.emit(ev.ControlFinished(outcome=out))
             return out
         try:
@@ -530,59 +609,36 @@ class DhcpEngine:
 
                 mac = get_if_hwaddr(self.cfg.interface)
         except Exception as exc:
-            out.reason = f"skipped (no hardware MAC: {exc!r})"
+            out = ControlOutcome(
+                phase=phase, client=client, reason=f"skipped (no hardware MAC: {exc!r})"
+            )
             self.bus.emit(ev.ControlFinished(outcome=out))
             return out
 
-        out.attempted = True
-        out.mac = mac
         self._our_macs.add(mac)
         self.bus.emit(ev.ControlStarted(phase=phase))
         started = time.time()
         xid = _rand_xid()
         with self._control_lock:
             self._control_xid = xid
-            self._control_offer = None
-            self._control_ack = None
-            self._control_nak = False
-        self._control_offer_evt.clear()
-        self._control_ack_evt.clear()
+        max_attempts = max(1, self.cfg.control_attempts)
+        out = ControlOutcome(phase=phase, client=client, mac=mac)
         try:
-            self._send(packets.build_discover_v4(mac, xid, mac), probe=True)
-            who = "real NIC MAC" if client == "self" else "fresh unseen MAC"
-            self._debug(f"CONTROL[{phase}/{client}] DISCOVER xid=0x{xid:08x} chaddr={mac} ({who})")
-            if not self._control_offer_evt.wait(self.cfg.timeouts.control):
-                out.reason = "no OFFER within timeout"
-                return out
-            if self._control_nak:
-                out.reason = "server replied NAK"
-                return out
-            offer = self._control_offer
-            sid, server_mac, offered_ip, subnet = packets.parse_offer(offer)
-            out.offered_ip, out.server_id, out.subnet = offered_ip, sid, subnet
-            out.server_mac = server_mac or None
-            self._note_offer_for_pool_estimate(offered_ip, subnet)
-            lt = packets.dhcp_option(offer[DHCP].options, "lease_time")
-            out.lease_time = int(lt) if isinstance(lt, int) else None
-            self._debug(f"CONTROL[{phase}/{client}] OFFER {offered_ip} from {sid} subnet={subnet}")
-            self._send(packets.build_request_v4(offer, mac), probe=True)
-            self.requests_sent += 1
-            if not self._control_ack_evt.wait(self.cfg.timeouts.control):
-                out.reason = f"OFFER {offered_ip} but no ACK within timeout"
-                return out
-            if self._control_nak:
-                out.reason = f"OFFER {offered_ip} then NAK"
-                return out
-            out.success = True
-            self._debug(
-                f"CONTROL[{phase}/{client}] ACK {offered_ip} — this client can obtain a lease"
-            )
-            # give the address straight back; the control must not consume pool capacity
-            self._send(
-                packets.build_release_v4(mac, offered_ip, sid, xid, server_mac=server_mac),
-                probe=True,
-            )
-            self._debug(f"CONTROL[{phase}/{client}] RELEASE {offered_ip}")
+            for attempt in range(1, max_attempts + 1):
+                out = self._control_attempt(phase, client, mac, xid)
+                out.attempts = attempt
+                if out.success or self._control_nak:
+                    break  # a definite answer -- nothing to retry
+                if attempt < max_attempts:
+                    self._debug(
+                        f"CONTROL[{phase}/{client}] attempt {attempt}/{max_attempts} failed "
+                        f"({out.reason}); retrying"
+                    )
+                    if self._stop.wait(1.0):
+                        break
+            if not out.success and out.attempts:
+                plural = "" if out.attempts == 1 else "s"
+                out.reason = f"{out.reason} ({out.attempts} attempt{plural})"
         except Exception as exc:  # a broken control must never kill the run
             out.reason = f"error: {exc!r}"
         finally:
@@ -626,6 +682,24 @@ class DhcpEngine:
             for xid, ip in self._reacquire_targets.items()
             if self._reacquire_outcomes.get(xid) == "granted"
         }
+
+    def _leases_expired(self, now: float | None = None) -> int:
+        """Leases we took whose server-granted lease time ran out before the run ended.
+
+        Not a failure of the run and not evidence of anything about the network -- it is the
+        reason a post-run control can succeed against a pool this run genuinely drained. On a
+        short-lease network (a guest SSID's 10-minute lease is a real example) a long-running
+        exhaust can lose its own early leases mid-run without anything else in the report saying
+        so, which makes `post_new.success` look like unexplained headroom instead of what it
+        actually is. Counted only, never renewed -- see docs/DESIGN.md §5d for why renewal is
+        out of scope here.
+        """
+        now = time.time() if now is None else now
+        return sum(
+            1
+            for ln in self.cleanup.all()
+            if not ln.released and ln.lease_time and now > ln.acquired_at + ln.lease_time
+        )
 
     def _renewal_suffix(self, ip: str) -> str:
         """`" (~12h)"` when the pool's lease duration is known, `""` when it isn't.
@@ -858,7 +932,10 @@ class DhcpEngine:
             )
             return steps
 
-        step("ARP inventory", f"{self._baseline_neighbor_count} devices")
+        sweep_note = (
+            f" ({self._sweep_skipped} address(es) not probed)" if self._sweep_skipped else ""
+        )
+        step("ARP inventory", f"{self._baseline_neighbor_count} devices{sweep_note}")
         if mode is Mode.ACTIVE_SCAN:
             step("DHCPINFORM to identify servers", f"{len(self.servers)} found")
             return steps
@@ -913,6 +990,9 @@ class DhcpEngine:
                     tail = "server stopped answering"
                 else:
                     tail = "stopped by the operator"
+                expired = self._leases_expired()
+                if expired:
+                    tail += f"; {expired} expired before the retest"
                 step(
                     f"Drained the pool{dry}",
                     f"{self.acks} held of {self.discovers}; {tail}",
@@ -1003,6 +1083,7 @@ class DhcpEngine:
                     {
                         "total": len(rollcall),
                         "by_category": by_category,
+                        "addresses_not_probed": self._sweep_skipped,
                         # pre-formatted one line per host: both renderers print list evidence
                         # one item per line, and every surface is monospace, so the columns line
                         # up without either front end knowing the shape of a host row.
@@ -1057,7 +1138,11 @@ class DhcpEngine:
             )
         if self.cfg.mode is Mode.EXHAUST and self._baseline_neighbor_count:
             est, _ = self._pool_headroom()
-            if est.size:
+            # observed_span is a lower bound, not the real denominator -- utilization against it
+            # runs artificially high (a handful of hosts can make a tight span look "full"), so
+            # it must not drive this finding. Only scope (deterministic) or observed (a whole
+            # subnet, therefore never smaller than the real scope) are honest denominators here.
+            if est.size and est.source in ("scope", "observed"):
                 utilization = self._baseline_neighbor_count / est.size
                 if utilization >= 0.8:
                     self._raise(
@@ -1102,11 +1187,18 @@ class DhcpEngine:
                                 "renewal_still_worked": bool(post and post.success),
                                 "elapsed_sec": elapsed,
                                 "servers": list(self.servers),
+                                "post_new_attempts": post_new.attempts,
+                                "leases_expired_during_run": self._leases_expired(),
                             },
                         )
                     )
                 else:
-                    evidence: dict = {"reason": reason, "leases_held": self.acks}
+                    evidence: dict = {
+                        "reason": reason,
+                        "leases_held": self.acks,
+                        "post_new_attempts": post_new.attempts,
+                        "leases_expired_during_run": self._leases_expired(),
+                    }
                     signal = detail = leases_at_halt = headroom = None
                     if reason == "control_fired" and self._halt_signal is not None:
                         signal, detail, leases_at_halt = self._halt_signal
@@ -1129,21 +1221,6 @@ class DhcpEngine:
                                 leases_at_halt=leases_at_halt,
                                 headroom=headroom,
                             ),
-                        )
-                    )
-
-                # offers stopped, yet a brand-new client is still served: that is the server
-                # refusing our traffic specifically, not running out of addresses
-                if post_new.success and self.state == EXHAUSTED:
-                    self._raise(
-                        findings.build(
-                            "SERVER_STOPPED_SERVING_TEST_CLIENTS",
-                            {
-                                "leases_before_offers_ceased": self.acks,
-                                "discovers": self.discovers,
-                                "naks": self.naks,
-                                "new_client_ip": post_new.offered_ip,
-                            },
                         )
                     )
 
@@ -1686,22 +1763,46 @@ class DhcpEngine:
 
     # ---------------------------------------------------------------- pool estimate / headroom
     def _note_offer_for_pool_estimate(self, offered_ip: str, subnet: str | None) -> None:
-        """Remember the first OFFER's address+subnet, in case --scope was never given.
+        """Remember the first OFFER's address+subnet, in case --scope was never given, and fold
+        every in-subnet OFFER into a measured lower-bound span (2.7.3, `observed_span` in
+        `_estimate_pool()`).
 
-        Called from both the real sender path and the control transaction, so the estimate
-        becomes available as soon as *any* OFFER is seen — usually the control/self leg, well
-        before the exhaust sender sends its first packet.
+        Called from both the real sender path and the control transaction -- and, since
+        `_handle_offer()`'s passive half calls it before the ownership check, from *anyone's*
+        OFFER on the segment, not just ours. That is deliberate here: an address a stranger was
+        offered is still direct evidence of what the scope contains, unlike the exhaustion
+        counters this must stay separate from (§8).
         """
         if self._first_offer_ip is None and subnet:
             self._first_offer_ip, self._first_offer_subnet = offered_ip, subnet
+        if not self._first_offer_subnet:
+            return
+        try:
+            prefixlen = netutils.cidr_from_mask(self._first_offer_subnet)
+            net = ipaddress.ip_network(f"{self._first_offer_ip}/{prefixlen}", strict=False)
+            addr = ipaddress.ip_address(offered_ip)
+        except (ValueError, OSError):
+            return
+        if addr not in net:
+            return  # a second scope on the segment -- don't let it skew the first scope's span
+        value = int(addr)
+        self._pool_lo = value if self._pool_lo is None else min(self._pool_lo, value)
+        self._pool_hi = value if self._pool_hi is None else max(self._pool_hi, value)
+        self._pool_seen += 1
+
+    # a real DHCP scope is usually a slice of its subnet (e.g. .100-.200 in a /24), so the
+    # subnet-mask estimate below overestimates -- observed_span needs enough samples that a
+    # two-offer run can't be mistaken for a tiny pool.
+    _POOL_SPAN_MIN_SAMPLES = 8
 
     def _estimate_pool(self) -> PoolEstimate:
         """Best-effort pool size. Never fabricated — `size=None` when nothing is known yet.
 
-        Resolution order: an explicit --scope (deterministic host count) beats inferring the
-        subnet from an OFFER (option 1), which is itself only as good as what the server told
-        us — reservations, exclusions, and additional scopes on the same segment are invisible
-        from here.
+        Resolution order: an explicit --scope (deterministic host count) beats an observed
+        address span (a measured *lower* bound — every address seen offered inside the subnet is
+        direct proof the scope contains it, unlike the subnet-mask guess below it), which beats
+        inferring the subnet from an OFFER (option 1) wholesale (§10's overestimate — reservations,
+        exclusions, and additional scopes on the same segment are all invisible from here).
         """
         if self.cfg.scope_cidrs:
             try:
@@ -1717,6 +1818,21 @@ class DhcpEngine:
                 )
             except ValueError:
                 pass
+        if (
+            self._pool_seen >= self._POOL_SPAN_MIN_SAMPLES
+            and self._pool_lo is not None
+            and self._pool_hi is not None
+        ):
+            lo_ip, hi_ip = netutils.int_to_ip(self._pool_lo), netutils.int_to_ip(self._pool_hi)
+            return PoolEstimate(
+                size=self._pool_hi - self._pool_lo + 1,
+                source="observed_span",
+                is_estimate=True,
+                detail=(
+                    f"lower bound: {self._pool_seen} address(es) observed between "
+                    f"{lo_ip} and {hi_ip}"
+                ),
+            )
         if self._first_offer_ip and self._first_offer_subnet:
             try:
                 prefixlen = netutils.cidr_from_mask(self._first_offer_subnet)
@@ -1788,7 +1904,16 @@ class DhcpEngine:
     def _reap_timeouts(self) -> None:
         """Free in-flight slots that never got a reply. A timeout shrinks the window exactly
         like a NAK does — a half-open allocation that never completes is the same signal that
-        the server (or the network) can't keep up, whichever end caused it."""
+        the server (or the network) can't keep up, whichever end caused it.
+
+        `_stalled_reaps` counts *reap cycles that expired something*, not expired xids — with
+        `window_initial=8` and a clean run, the pool draining expires up to a whole window's
+        worth of in-flight handshakes in one reap, and that single burst is not "N consecutive
+        timeouts" in any meaningful sense. It also does not accumulate once offers have ceased
+        altogether: at that point timeouts are the expected symptom of a drained pool, which
+        `offer_silence` (§5c) already owns — without this guard `timeout_storm` reliably wins
+        the race against it (5 reaps happen well inside `offer_silence`'s 10s window), so a
+        clean drain gets reported as a defensive control firing instead of exhaustion."""
         now = time.time()
         limit = self.cfg.timeouts.dhcp_request
         with self._inflight_lock:
@@ -1800,15 +1925,20 @@ class DhcpEngine:
         for xid in expired:
             self._classify_targeted(xid, "no_response", overwrite=False)
         self.timeouts_seen += len(expired)
-        self._consecutive_timeouts += len(expired)
         self._shrink_window("timeout")
+        offers_ceased = self._offers_seen_any and (now - self._last_offer_ts) > limit
+        if not offers_ceased:
+            self._stalled_reaps += 1
+        ceased_note = " (offers already ceased -- not counted toward timeout_storm)"
         self._debug(
             f"{len(expired)} handshake(s) timed out (no reply within {limit}s); "
-            f"{self._consecutive_timeouts} consecutive"
+            f"{self._stalled_reaps} consecutive stalled reap(s)"
+            + (ceased_note if offers_ceased else "")
         )
-        if self._consecutive_timeouts >= 5:
+        if self._stalled_reaps >= 5:
             self._trigger_halt(
-                "timeout_storm", f"{self._consecutive_timeouts} consecutive handshake timeouts"
+                "timeout_storm",
+                f"{self._stalled_reaps} consecutive reap cycles with no completed handshake",
             )
 
     def _note_nak_for_burst_detection(self) -> None:
@@ -2026,7 +2156,13 @@ class DhcpEngine:
         xid = _rand_xid()
         src = self._src_mac(client_mac)
         self._our_macs.add(src)
-        pkt = packets.build_discover_v4(client_mac, xid, src, requested_addr=requested_addr)
+        pkt = packets.build_discover_v4(
+            client_mac,
+            xid,
+            src,
+            requested_addr=requested_addr,
+            request_options=self.cfg.request_options,
+        )
         self._send(pkt)
         with self._inflight_lock:
             self._inflight[xid] = {
@@ -2140,9 +2276,11 @@ class DhcpEngine:
             self._debug("arp sweep skipped: could not determine a network range for the interface")
             return
         self._debug(f"arp sweep starting over {', '.join(cidrs)} (pre-run inventory)")
-        found, _ = self._discover_neighbors(cidrs)
+        found, skipped = self._discover_neighbors(cidrs)
         self._baseline_neighbor_count = len(found)
-        self._debug(f"arp sweep: {len(found)} host(s) present before exhausting")
+        self._sweep_skipped = skipped
+        skip_note = f"; {skipped} address(es) not probed (past the per-CIDR cap)" if skipped else ""
+        self._debug(f"arp sweep: {len(found)} host(s) present before exhausting{skip_note}")
 
     def _sweep_cidrs(self) -> list[str]:
         """Range for the *non-destructive* baseline sweep: explicit scope, else the iface network.
@@ -2341,12 +2479,11 @@ class DhcpEngine:
         except Exception as exc:
             self.bus.emit(ev.ErrorEvent(message=f"foreign discover parse error: {exc!r}"))
 
-    def _handle_offer(self, pkt) -> None:
-        self.offers += 1
-        self._offers_seen_any = True
-        self._last_offer_ts = time.time()
-        self._silence_noticed = False  # offers resumed; re-arm the quiet-period notice
-        server_id, server_mac, offered_ip, subnet = packets.parse_offer(pkt)
+    def _register_server(
+        self, pkt, server_id: str, server_mac: str, subnet: str | None
+    ) -> ServerInfo:
+        """First-sighting bookkeeping for a DHCP server observed in an OFFER -- passive, safe to
+        run for any OFFER on the segment regardless of whose transaction it answers."""
         server = self.servers.get(server_id)
         if server is None:
             server = ServerInfo(server_id, server_mac, subnet, self.cfg.ip_version)
@@ -2356,30 +2493,51 @@ class DhcpEngine:
             self.servers[server_id] = server
             self.bus.emit(ev.ServerDiscovered(server=server))
         server.offers_seen += 1
+        return server
+
+    def _handle_offer(self, pkt) -> None:
+        """Split into a passive half (true regardless of whose transaction this OFFER answers --
+        server identity, the pool-size estimate, marking a tracked foreign DISCOVER answered) and
+        an owned half (our exhaustion measurement and the REQUEST leg), gated by xid ownership.
+
+        BUG FIX (2.3, found while designing race-freed): this used to build and send a REQUEST
+        for *every* OFFER seen on the wire, with no check that the xid was ours -- an offer meant
+        for another real client made us impersonate their MAC and try to steal their address.
+        BUG FIX (2.7.3): the exhaustion-measurement counters (`self.offers`, `_offers_seen_any`,
+        `_last_offer_ts`) were incremented *before* that same ownership check, so any foreign
+        OFFER on a promiscuous BPF (another client's churn, a second scope) kept resetting the
+        exhaustion clock and inflating the offers counter -- `offer_silence` could never fire on
+        a busy segment. `xid in self._inflight` is the same ownership check `_handle_nak()` uses:
+        populated for every DISCOVER we actually sent (exhaust flood, re-acquisition, racing).
+        """
+        server_id, server_mac, offered_ip, subnet = packets.parse_offer(pkt)
         xid = pkt[BOOTP].xid
-        # BUG FIX (2.3, found while designing race-freed): this used to build and send a REQUEST
-        # for *every* OFFER seen on the wire, with no check that the xid was ours. Since
-        # client_mac_from_offer() reads chaddr straight off the OFFER, an offer meant for some
-        # other real client on the segment made us send a REQUEST impersonating *their* MAC,
-        # trying to steal their own offered address out from under them -- not scoped to
-        # anything we deliberately targeted, just every offer the sniffer happened to see.
-        # `xid in self._inflight` is the same ownership check `_handle_nak()` uses: populated
-        # for every DISCOVER we actually sent (exhaust flood, re-acquisition, racing).
+
+        # --- passive: true regardless of whose transaction this is ---
+        server = self._register_server(pkt, server_id, server_mac, subnet)
+        self._note_offer_for_pool_estimate(offered_ip, subnet)
+        foreign = self._foreign_discovers.get(xid)
+        if foreign is not None:
+            foreign["answered"] = True  # legitimate to record either way -- we're not acting on it
+
         with self._inflight_lock:
             info = self._inflight.get(xid)
             ours = info is not None
             if info is not None:
                 info["state"] = "REQUEST_SENT"
                 info["sent_at"] = time.time()  # restart the timeout clock for the ACK leg
-        foreign = self._foreign_discovers.get(xid)
-        if foreign is not None:
-            foreign["answered"] = True  # legitimate to record either way -- we're not acting on it
         if not ours:
             self._debug(
                 f"foreign OFFER xid=0x{xid:08x} yiaddr={offered_ip} server_id={server_id} "
                 "(not ours, not requesting)"
             )
             return
+
+        # --- owned: drives the exhaustion measurement and sends the REQUEST leg ---
+        self.offers += 1
+        self._offers_seen_any = True
+        self._last_offer_ts = time.time()
+        self._silence_noticed = False  # offers resumed; re-arm the quiet-period notice
         lease = Lease(
             packets.client_mac_from_offer(pkt),
             offered_ip,
@@ -2388,7 +2546,6 @@ class DhcpEngine:
             self.cfg.ip_version,
         )
         self._note_offer_for_duplicate_detection(offered_ip, lease.mac)
-        self._note_offer_for_pool_estimate(offered_ip, subnet)
         self.bus.emit(ev.OfferReceived(lease=lease, server=server))
         self._debug(
             f"OFFER xid=0x{pkt[BOOTP].xid:08x} yiaddr={offered_ip} server_id={server_id} "
@@ -2475,7 +2632,7 @@ class DhcpEngine:
         if requested is not None:
             outcome = "granted" if ip == requested else "offered_different"
             self._classify_targeted(xid, outcome)
-        self._consecutive_timeouts = 0  # a clean handshake resets the timeout-storm counter
+        self._stalled_reaps = 0  # a clean handshake resets the timeout-storm counter
         self._grow_window()
         self.bus.emit(ev.AckReceived(lease=lease))
         self._debug(
@@ -2777,28 +2934,22 @@ class DhcpEngine:
         else:
             self._raise(findings.build("POOL_RECOVERY_FAILED", evidence))
 
-    def _discover_neighbors(
-        self, cidrs: list[str] | None = None
-    ) -> tuple[list[Neighbor], str | None]:
+    def _discover_neighbors(self, cidrs: list[str] | None = None) -> tuple[list[Neighbor], int]:
         """ARP-sweep for live neighbors (best effort; needs a real iface).
 
         `cidrs` defaults to cfg.scope_cidrs. Destructive callers MUST leave it unset so their
-        targets stay pinned to the authorised scope.
+        targets stay pinned to the authorised scope. Returns `(neighbors, skipped)` --
+        `skipped` is how many addresses `_sweep_targets()` left unprobed past its per-CIDR cap
+        (§5); callers that care surface it, callers that don't discard it as `_`.
         """
         from scapy.all import srp  # monkeypatched -- see top of file
 
         found: dict[str, Neighbor] = {}
         src_ip = netutils.get_if_ip(self.cfg.interface) or "0.0.0.0"
-        targets: list[str] = []
-        for cidr in (cidrs if cidrs is not None else self.cfg.scope_cidrs) or []:
-            net = ipaddress.ip_network(cidr, strict=False)
-            # BUG FIX (2.3): `list(net.hosts())[:1024]` materialized every host in the network
-            # before slicing -- a /8 (as "lo" auto-detects to) means ~16M IPv4Address objects
-            # built just to keep the first 1024, several real seconds of dead time before the
-            # sweep even sends a packet. islice caps the work at 1024 regardless of network size.
-            targets += [str(h) for h in itertools.islice(net.hosts(), 1024)]
+        sweep_cidrs = cidrs if cidrs is not None else (self.cfg.scope_cidrs or [])
+        targets, skipped = _sweep_targets(sweep_cidrs)
         if not targets or self.cfg.offline:
-            return list(found.values()), None
+            return list(found.values()), skipped
         try:
             self.arp_requests_sent += len(targets)
             ans, _ = srp(
@@ -2811,7 +2962,28 @@ class DhcpEngine:
                 found[r.psrc] = self._note_neighbor(r.hwsrc, r.psrc)
         except Exception as exc:
             self.bus.emit(ev.ErrorEvent(message=f"arp sweep error: {exc!r}"))
-        return list(found.values()), None
+        return list(found.values()), skipped
+
+
+def _sweep_targets(cidrs: list[str], cap: int = ARP_SWEEP_MAX_TARGETS) -> tuple[list[str], int]:
+    """(targets, skipped) — the first `cap` hosts of each CIDR, and how many were left unprobed.
+
+    Pure and root-free, so it's unit-testable on its own. `skipped` is computed as
+    `usable_hosts - len(targets)` per CIDR (O(1) via `num_addresses`) rather than by counting
+    `net.hosts()` -- materializing a /8's ~16M host objects just to count them is exactly the
+    dead-time bug `itertools.islice` below already exists to avoid.
+    """
+    targets: list[str] = []
+    skipped = 0
+    for cidr in cidrs:
+        net = ipaddress.ip_network(cidr, strict=False)
+        usable = max(0, net.num_addresses - 2)
+        # islice caps the work at `cap` regardless of network size -- see the module-level
+        # ARP_SWEEP_MAX_TARGETS comment for why this cap exists and how it's surfaced.
+        cidr_targets = [str(h) for h in itertools.islice(net.hosts(), cap)]
+        targets += cidr_targets
+        skipped += max(0, usable - len(cidr_targets))
+    return targets, skipped
 
 
 def _rand_xid() -> int:

--- a/src/dhcpig/core/findings.py
+++ b/src/dhcpig/core/findings.py
@@ -91,17 +91,6 @@ _CATALOG: dict[str, dict] = {
         "severity": "info",
         "recommendation": "",
     },
-    "SERVER_STOPPED_SERVING_TEST_CLIENTS": {
-        "title": ("Server stopped answering the test clients while still serving a new client"),
-        "verdict": INFO,
-        "severity": "medium",
-        "recommendation": (
-            "Consistent with DHCP rate-limiting, offer-table saturation "
-            "or anti-starvation protection rather than pool exhaustion. "
-            "A NAK burst just before offers ceased points at the server "
-            "re-offering already-pending addresses."
-        ),
-    },
     "DRY_RUN_SUMMARY": {
         "title": "Dry run: reconnaissance only, nothing sent that would take a lease",
         "verdict": INFO,

--- a/src/dhcpig/core/models.py
+++ b/src/dhcpig/core/models.py
@@ -83,7 +83,11 @@ class SessionConfig:
     # at Layer 2 (exercises port-security / DHCP snooping). Set False for Wi-Fi (APs drop
     # frames with foreign/multiple source MACs) — then only the BOOTP chaddr is randomized.
     spoof_ethernet_src: bool = True
-    request_options: list[int] = field(default_factory=lambda: list(range(80)))
+    # DHCP option 55 (parameter-request-list) content for the sending client, on exhaust and
+    # active-scan (`--request-option`, e.g. "12,14-19,23"). `None` uses the built-in macOS-order
+    # profile (`packets._MACOS_PRL`) -- never applied to the control transaction's own DISCOVER,
+    # which must stay a vanilla client since it's the baseline the verdict is measured against.
+    request_options: list[int] | None = None
     rate_limit_pps: int = 7  # the bound on how fast a run can consume a pool
     dry_run: bool = False
     # Hard "never touch a socket" switch, distinct from dry_run (2.3). dry_run now runs every
@@ -100,6 +104,13 @@ class SessionConfig:
     # real NIC MAC always runs before and after exhausting — it's what separates "the network
     # blocked us" (PASS) from "the test was broken" (INCONCLUSIVE), and a run without it can't
     # produce a trustworthy verdict. Don't re-add a `control` field without asking.
+    # How many times a control leg retransmits its DISCOVER/REQUEST before giving up (2.7.3).
+    # The verdict is derived from a single control leg's success/failure -- one lost UDP packet
+    # used to be able to flip DHCP_STARVATION_ATTAINED to a false FAIL, or
+    # NEW_CLIENT_BLOCKED_AT_BASELINE to a false PASS. Retried only on "nothing came back"; a NAK
+    # is a definite answer and stops immediately (§5a). Same mac/xid across attempts -- this is
+    # one logical transaction being retransmitted, per RFC 2131, not a new one each time.
+    control_attempts: int = 3
     # The pre-run ARP sweep is unconditional -- there is no `arp_sweep` field and no
     # --no-arp-scan flag. Every phase after it reads the inventory it builds (release targets,
     # re-acquisition, eviction, the NeighborSummary roll-call), so turning it off silently
@@ -279,6 +290,10 @@ class ControlOutcome:
     lease_time: int | None = None
     elapsed: float = 0.0
     reason: str = ""  # why it was skipped or failed
+    # how many DISCOVER attempts this transaction made (0 if skipped before ever sending one) --
+    # the verdict is derived from this leg's success/failure, so a report showing a FAIL or a
+    # "blocked at baseline" PASS must be able to say it wasn't just one lost packet (§5a).
+    attempts: int = 0
 
 
 # Finding verdicts. PASS = a defense demonstrably worked; FAIL = the network did not defend;

--- a/src/dhcpig/core/packets.py
+++ b/src/dhcpig/core/packets.py
@@ -32,15 +32,25 @@ def _hostname() -> str:
 # --------------------------------------------------------------------------- builders
 
 
-def build_discover_v4(mac: str, xid: int, src_mac: str, requested_addr: str | None = None) -> Ether:
+def build_discover_v4(
+    mac: str,
+    xid: int,
+    src_mac: str,
+    requested_addr: str | None = None,
+    request_options: list[int] | None = None,
+) -> Ether:
     """`requested_addr` emits DHCP option 50 (RFC 2131 Table 5 permits it in a DISCOVER) --
     used by targeted re-acquisition (2.3) to ask the server for a specific, just-released
     address rather than whatever it would otherwise hand out. Servers generally honour it when
     the address is free; nothing here assumes they do -- the caller must still check the OFFER.
+
+    `request_options` overrides the option-55 (parameter-request-list) content; `None` keeps the
+    built-in `_MACOS_PRL`. The control transaction's own DISCOVER never passes this -- it must
+    stay a vanilla, unmodified client, because it's the baseline the verdict is measured against.
     """
     opts = [
         ("message-type", "discover"),
-        ("param_req_list", *_MACOS_PRL),
+        ("param_req_list", *(request_options or _MACOS_PRL)),
         ("max_dhcp_size", 1500),
         ("client_id", b"\x01" + mac2str(mac)),
         ("lease_time", 10000),
@@ -141,12 +151,18 @@ def build_release_v4(
     )
 
 
-def build_inform_v4(mac: str, ciaddr: str, xid: int, request_options=None) -> Ether:
+def build_inform_v4(
+    mac: str, ciaddr: str, xid: int, request_options: list[int] | None = None
+) -> Ether:
     """DHCP INFORM: sent by a host that already has an IP to actively pull config from the
-    server (used by active-scan to discover/fingerprint DHCP servers). Takes no lease."""
+    server (used by active-scan to discover/fingerprint DHCP servers). Takes no lease.
+
+    `request_options` overrides the option-55 content, same as `build_discover_v4()`; `None`
+    keeps the built-in `_MACOS_PRL`.
+    """
     opts = [
         ("message-type", "inform"),
-        ("param_req_list", *_MACOS_PRL),
+        ("param_req_list", *(request_options or _MACOS_PRL)),
         ("client_id", b"\x01" + mac2str(mac)),
         "end",
     ]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -17,6 +17,15 @@ def test_build_config_exhaust_defaults():
     assert cfg.mode is Mode.EXHAUST
     assert cfg.ip_version is IPVersion.V4
     assert cfg.spoof_ethernet_src is True  # distinct L2 MACs by default
+    # None means "use the built-in macOS-order profile" -- see SessionConfig.request_options
+    assert cfg.request_options is None
+
+
+def test_request_option_reaches_the_config_on_exhaust_and_active_scan():
+    for cmd in ("exhaust", "active-scan"):
+        args = cli.build_parser().parse_args([cmd, "eth1", "--request-option", "12,14-16,23"])
+        cfg = cli.build_config(args)
+        assert cfg.request_options == [12, 14, 15, 16, 23]
 
 
 def test_exhaust_has_no_no_control_flag():

--- a/tests/unit/test_control_transaction.py
+++ b/tests/unit/test_control_transaction.py
@@ -90,6 +90,7 @@ def test_control_still_probes_under_dry_run(monkeypatch):
     eng, _, sent = _engine(monkeypatch, dry_run=True)
     monkeypatch.setattr("scapy.all.get_if_hwaddr", lambda _i: "00:11:22:33:44:55")
     eng.cfg.timeouts.control = 0.15  # nobody answers -- we only care that it actually sent
+    eng.cfg.control_attempts = 1  # single attempt: this test only cares about the first DISCOVER
     out = eng._control_transaction("pre")
     assert out.attempted is True
     assert "dry-run" not in out.reason
@@ -134,9 +135,87 @@ def test_control_reports_failure_when_no_offer(monkeypatch):
     eng, _, _ = _engine(monkeypatch)
     monkeypatch.setattr("scapy.all.get_if_hwaddr", lambda _i: "00:11:22:33:44:55")
     eng.cfg.timeouts.control = 0.15  # nobody answers
+    eng.cfg.control_attempts = 1  # single attempt: this test is about the failure shape, not retry
     out = eng._control_transaction("pre")
     assert out.attempted and not out.success
     assert "no OFFER" in out.reason
+    assert out.attempts == 1
+    assert "1 attempt" in out.reason
+
+
+def test_control_retries_and_succeeds_when_the_first_offer_is_lost(monkeypatch):
+    """A lost OFFER on attempt 1 must not fail the whole transaction (2.7.3) -- the verdict is
+    derived from this leg's success/failure, so one dropped packet used to be able to flip it."""
+    eng, _, sent = _engine(monkeypatch)
+    monkeypatch.setattr(engine_mod, "sendp", lambda pkt, **kw: sent.append(pkt))
+    monkeypatch.setattr("scapy.all.get_if_hwaddr", lambda _i: "00:11:22:33:44:55")
+    eng.cfg.timeouts.control = 0.2
+    eng.cfg.control_attempts = 3
+
+    def responder():
+        for _ in range(200):
+            with eng._control_lock:
+                xid = eng._control_xid
+            if xid:
+                break
+            time.sleep(0.01)
+        time.sleep(1.3)  # let attempt 1 (0.2s) and the 1.0s retry gap elapse; land inside attempt 2
+        eng._on_dhcp(_reply("offer", xid, "00:11:22:33:44:55"))
+        eng._control_offer_evt.wait(1)
+        eng._on_dhcp(_reply("ack", xid, "00:11:22:33:44:55"))
+
+    t = threading.Thread(target=responder, daemon=True)
+    t.start()
+    out = eng._control_transaction("pre")
+    t.join(timeout=3)
+
+    assert out.success, out.reason
+    assert out.attempts == 2
+    # DISCOVER x2, REQUEST, RELEASE -- the lost-OFFER attempt only ever sent a DISCOVER
+    assert len(sent) == 4
+    assert packets.message_type(sent[0]) == packets.DISCOVER
+    assert packets.message_type(sent[1]) == packets.DISCOVER
+
+
+def test_control_nak_stops_retrying_immediately(monkeypatch):
+    """A NAK is a definite answer, not a lost packet -- retrying after one would just ask the
+    same question again and waste the run's time budget for no new information."""
+    eng, _, sent = _engine(monkeypatch)
+    monkeypatch.setattr(engine_mod, "sendp", lambda pkt, **kw: sent.append(pkt))
+    monkeypatch.setattr("scapy.all.get_if_hwaddr", lambda _i: "00:11:22:33:44:55")
+    eng.cfg.timeouts.control = 2.0
+    eng.cfg.control_attempts = 3
+
+    def responder():
+        for _ in range(200):
+            with eng._control_lock:
+                xid = eng._control_xid
+            if xid:
+                break
+            time.sleep(0.01)
+        eng._on_dhcp(_reply("nak", xid, "00:11:22:33:44:55"))
+
+    t = threading.Thread(target=responder, daemon=True)
+    t.start()
+    started = time.time()
+    out = eng._control_transaction("pre")
+    t.join(timeout=3)
+
+    assert not out.success
+    assert out.attempts == 1
+    assert "NAK" in out.reason
+    assert time.time() - started < 1.0  # no 1.0s retry gap, no second 2.0s timeout wait
+
+
+def test_control_reports_failure_after_exhausting_all_attempts(monkeypatch):
+    eng, _, _ = _engine(monkeypatch)
+    monkeypatch.setattr("scapy.all.get_if_hwaddr", lambda _i: "00:11:22:33:44:55")
+    eng.cfg.timeouts.control = 0.05  # nobody ever answers
+    eng.cfg.control_attempts = 3
+    out = eng._control_transaction("pre")
+    assert not out.success
+    assert out.attempts == 3
+    assert "3 attempts" in out.reason
 
 
 def test_control_replies_do_not_pollute_run_counters(monkeypatch):
@@ -262,6 +341,44 @@ def test_new_client_served_means_not_attained(monkeypatch):
     assert fs["DHCP_STARVATION_NOT_ATTAINED"].verdict == PASS
     assert fs["DHCP_STARVATION_NOT_ATTAINED"].evidence["reason"] == "pool_headroom_remaining"
     assert "DHCP_STARVATION_ATTAINED" not in fs
+    # zero-valued keys (no leases expired here) are dropped from the rendered summary
+    from dataclasses import asdict
+
+    from dhcpig.core.findings import finding_summary_lines
+
+    summary = "\n".join(finding_summary_lines(asdict(fs["DHCP_STARVATION_NOT_ATTAINED"])))
+    assert "leases_expired_during_run" not in summary
+
+
+def test_not_attained_evidence_carries_attempts_and_expired_lease_count(monkeypatch):
+    """A FAIL or a NOT_ATTAINED PASS must be auditable: how hard the post/new control tried, and
+    whether some of our own leases had already lapsed by the time it ran (2.7.3)."""
+    from dhcpig.core.models import IPVersion
+
+    eng, events, _ = _engine(monkeypatch, mode=Mode.EXHAUST)
+    eng._started = time.time()
+    eng.control_pre = ControlOutcome(phase="pre", client="self", attempted=True, success=True)
+    eng.control_pre_new = ControlOutcome(phase="pre", client="new", attempted=True, success=True)
+    eng.control_post_new = ControlOutcome(
+        phase="post", client="new", attempted=True, success=True, offered_ip="10.0.0.9", attempts=2
+    )
+    eng.acks = 5
+    eng.cleanup.register(
+        Lease(
+            "de:ad:00:00:00:01",
+            "10.0.0.5",
+            "10.0.0.254",
+            1,
+            IPVersion.V4,
+            lease_time=60,
+            acquired_at=time.time() - 120,  # expired well before the retest
+        )
+    )
+    eng._finalize_findings()
+    fs = {e.finding.id: e.finding for e in events if isinstance(e, ev.FindingRaised)}
+    ev_ = fs["DHCP_STARVATION_NOT_ATTAINED"].evidence
+    assert ev_["post_new_attempts"] == 2
+    assert ev_["leases_expired_during_run"] == 1
 
 
 def test_control_fired_is_the_reason_when_a_halt_signal_preceded_the_post_control(monkeypatch):
@@ -280,27 +397,6 @@ def test_control_fired_is_the_reason_when_a_halt_signal_preceded_the_post_contro
     assert ev_["reason"] == "control_fired"
     assert ev_["signal"] == "nak_burst"
     assert ev_["leases_at_halt"] == 40
-
-
-def test_offers_ceasing_while_new_client_served_is_a_throttle_not_exhaustion(monkeypatch):
-    """The real-network case: offers stop, but a brand-new client is still served."""
-    from dhcpig.core.engine import EXHAUSTED
-
-    eng, events, _ = _engine(monkeypatch, mode=Mode.EXHAUST)
-    eng._started = time.time()
-    eng.state = EXHAUSTED  # senders saw offers cease
-    eng.control_pre = ControlOutcome(phase="pre", client="self", attempted=True, success=True)
-    eng.control_pre_new = ControlOutcome(phase="pre", client="new", attempted=True, success=True)
-    eng.control_post_new = ControlOutcome(
-        phase="post", client="new", attempted=True, success=True, offered_ip="192.168.4.35"
-    )
-    eng.acks = 56
-    eng.naks = 8
-    eng._finalize_findings()
-    fs = {e.finding.id: e.finding for e in events if isinstance(e, ev.FindingRaised)}
-    assert "DHCP_STARVATION_ATTAINED" not in fs
-    assert "SERVER_STOPPED_SERVING_TEST_CLIENTS" in fs
-    assert fs["SERVER_STOPPED_SERVING_TEST_CLIENTS"].evidence["naks"] == 8
 
 
 def test_new_client_blocked_at_baseline_is_a_pass(monkeypatch):

--- a/tests/unit/test_core_extra.py
+++ b/tests/unit/test_core_extra.py
@@ -165,6 +165,96 @@ def test_engine_offer_then_ack_flow(monkeypatch):
     assert any(isinstance(e, ev.RequestSent) for e in events)
 
 
+def test_foreign_offer_does_not_pollute_exhaustion_measurement(monkeypatch):
+    """A foreign OFFER (xid we never sent) must not move offers/_offers_seen_any/_last_offer_ts
+    -- those drive the offer_silence halt signal, and a promiscuous BPF sees every client's DHCP
+    churn (2.7.3 bug fix: this used to be incremented before the ownership check)."""
+    eng, events, _ = _engine(monkeypatch)
+    offer = _dhcp("offer", chaddr=mac2str("de:ad:00:00:00:09") + b"\x00" * 10)  # xid 0x99, not ours
+    eng._on_dhcp(offer)
+    assert eng.offers == 0
+    assert eng._offers_seen_any is False
+    assert eng._last_offer_ts == 0.0
+
+
+def test_foreign_offer_still_registers_the_server_and_pool_estimate(monkeypatch):
+    """The passive half of _handle_offer runs for anyone's OFFER: server identity and the
+    pool-size estimate are facts about the network, not about our own run."""
+    eng, events, _ = _engine(monkeypatch)
+    offer = _dhcp("offer", chaddr=mac2str("de:ad:00:00:00:09") + b"\x00" * 10)  # not ours
+    eng._on_dhcp(offer)
+    assert len(eng.servers) == 1
+    assert any(isinstance(e, ev.ServerDiscovered) for e in events)
+    assert eng._first_offer_ip == "172.20.0.83"
+    assert eng._first_offer_subnet == "255.255.255.0"
+
+
+def test_leases_expired_counts_only_unreleased_leases_past_their_lease_time(monkeypatch):
+    import time as _t
+
+    eng, _, _ = _engine(monkeypatch)
+    now = _t.time()
+    eng.cleanup.register(
+        Lease(
+            "de:ad:00:00:00:01",
+            "10.0.0.1",
+            "10.0.0.254",
+            1,
+            IPVersion.V4,
+            lease_time=600,
+            acquired_at=now - 700,
+        )  # expired 100s ago
+    )
+    eng.cleanup.register(
+        Lease(
+            "de:ad:00:00:00:02",
+            "10.0.0.2",
+            "10.0.0.254",
+            2,
+            IPVersion.V4,
+            lease_time=600,
+            acquired_at=now - 100,
+        )  # still well within its lease
+    )
+    released = Lease(
+        "de:ad:00:00:00:03",
+        "10.0.0.3",
+        "10.0.0.254",
+        3,
+        IPVersion.V4,
+        lease_time=600,
+        acquired_at=now - 700,
+        released=True,
+    )
+    eng.cleanup.register(released)
+    no_lease_time = Lease(
+        "de:ad:00:00:00:04", "10.0.0.4", "10.0.0.254", 4, IPVersion.V4, acquired_at=now - 700
+    )  # lease_time unknown -- never counted
+    eng.cleanup.register(no_lease_time)
+    assert eng._leases_expired(now=now) == 1
+
+
+def test_push_discover_carries_cfg_request_options(monkeypatch):
+    """cfg.request_options reaches the flood's DISCOVER (2.7.3) -- it used to be accepted by
+    SessionConfig and never actually wired into any DISCOVER this tool sent."""
+    eng, _, sent = _engine(monkeypatch, dry_run=False, request_options=[12, 15])
+    eng._push_discover("de:ad:00:00:00:20")
+    assert len(sent) == 1
+    assert packets.dhcp_option(sent[0][DHCP].options, "param_req_list") == (12, 15)
+
+
+def test_control_transaction_ignores_cfg_request_options(monkeypatch):
+    """The control leg must stay a vanilla client regardless of cfg.request_options -- it's the
+    baseline the verdict is measured against, not part of the flood's fingerprint profile."""
+    eng, _, sent = _engine(monkeypatch, dry_run=False, request_options=[12, 15])
+    monkeypatch.setattr("scapy.all.get_if_hwaddr", lambda _i: "00:11:22:33:44:55")
+    eng.cfg.timeouts.control = 0.05  # nobody answers -- only the DISCOVER shape matters here
+    eng.cfg.control_attempts = 1
+    eng._control_transaction("pre")
+    assert len(sent) == 1
+    assert packets.dhcp_option(sent[0][DHCP].options, "param_req_list") == packets._MACOS_PRL
+
+
 def test_exhaust_sender_stops_when_offers_cease(monkeypatch):
     """The only self-terminating condition is the *server* going quiet — there is no lease cap."""
     import time as _t

--- a/tests/unit/test_packets.py
+++ b/tests/unit/test_packets.py
@@ -40,6 +40,31 @@ def test_discover_carries_option50_when_requested_addr_given():
     # message-type and client_id must both still be present -- option 50 is additive
 
 
+# ---------------------------------------------------------------- --request-option (2.7.3)
+def test_discover_uses_macos_prl_by_default():
+    pkt = packets.build_discover_v4("de:ad:00:00:00:10", 0x1001, "de:ad:00:00:00:10")
+    assert packets.dhcp_option(pkt[DHCP].options, "param_req_list") == packets._MACOS_PRL
+
+
+def test_discover_carries_the_given_request_options_when_provided():
+    pkt = packets.build_discover_v4(
+        "de:ad:00:00:00:11", 0x1002, "de:ad:00:00:00:11", request_options=[1, 3, 6]
+    )
+    assert packets.dhcp_option(pkt[DHCP].options, "param_req_list") == (1, 3, 6)
+
+
+def test_inform_uses_macos_prl_by_default():
+    pkt = packets.build_inform_v4("de:ad:00:00:00:12", "192.168.1.50", 0x1003)
+    assert packets.dhcp_option(pkt[DHCP].options, "param_req_list") == packets._MACOS_PRL
+
+
+def test_inform_carries_the_given_request_options_when_provided():
+    pkt = packets.build_inform_v4(
+        "de:ad:00:00:00:13", "192.168.1.50", 0x1004, request_options=[12, 15]
+    )
+    assert packets.dhcp_option(pkt[DHCP].options, "param_req_list") == (12, 15)
+
+
 # ---------------------------------------------------------------- packet_hostname (2.3)
 def test_packet_hostname_decodes_our_own_discover_and_request():
     """Our own DISCOVER/REQUEST always carry a random hostname (option 12) -- packet_hostname()

--- a/tests/unit/test_release_phase.py
+++ b/tests/unit/test_release_phase.py
@@ -103,6 +103,44 @@ def test_destructive_discovery_is_not_widened_by_the_sweep_fallback(monkeypatch)
     assert all(t.startswith("10.9.9.") for t in seen["targets"])
 
 
+# ---------------------------------------------------------------- ARP sweep truncation (2.7.3)
+def test_sweep_targets_caps_per_cidr_and_reports_what_it_skipped():
+    """Pure, root-free: a /16 is capped at `cap` targets, and `skipped` says how many usable
+    addresses were left unprobed -- computed from num_addresses, not by materializing them."""
+    from dhcpig.core.engine import _sweep_targets
+
+    targets, skipped = _sweep_targets(["10.0.0.0/16"], cap=1024)
+    assert len(targets) == 1024
+    assert skipped == 65534 - 1024
+
+
+def test_sweep_targets_reports_no_skip_when_the_cidr_fits_under_the_cap():
+    from dhcpig.core.engine import _sweep_targets
+
+    targets, skipped = _sweep_targets(["10.0.0.0/24"], cap=1024)
+    assert len(targets) == 254
+    assert skipped == 0
+
+
+def test_sweep_targets_sums_skipped_across_multiple_cidrs():
+    from dhcpig.core.engine import _sweep_targets
+
+    targets, skipped = _sweep_targets(["10.0.0.0/24", "10.0.1.0/24"], cap=100)
+    assert len(targets) == 200  # 100 from each
+    assert skipped == (254 - 100) * 2
+
+
+def test_baseline_arp_scan_surfaces_truncation_in_the_run_summary(monkeypatch):
+    """A wide scope must not silently present a partial host list as the whole segment."""
+    eng, _, _ = _engine(monkeypatch, mode=Mode.EXHAUST, scope_cidrs=["10.0.0.0/16"], dry_run=True)
+    monkeypatch.setattr("scapy.all.srp", lambda pkt, **kw: ([], []))
+    eng._baseline_arp_scan()
+    assert eng._sweep_skipped == 65534 - 1024
+    steps = eng._run_summary_steps()
+    arp_step = next(s for s in steps if s["did"] == "ARP inventory")
+    assert "not probed" in arp_step["got"]
+
+
 # ---------------------------------------------------------------- release phase (exhaust)
 def test_release_phase_skipped_without_a_known_server(monkeypatch):
     """BUG FIX (2.1): must never fall back to server_id=0.0.0.0 — skip instead."""

--- a/tests/unit/test_window_halt.py
+++ b/tests/unit/test_window_halt.py
@@ -151,20 +151,48 @@ def test_foreign_naks_do_not_trigger_halt(monkeypatch):
     assert not any(isinstance(e, ev.ControlDetected) for e in events)
 
 
-def test_timeout_storm_triggers_halt(monkeypatch):
+def test_timeout_storm_needs_five_stalled_reap_cycles_not_five_expired_xids(monkeypatch):
+    """_stalled_reaps counts reap *cycles* that expired something, not expired xids -- a window
+    of 8 in-flight handshakes expiring together in one reap is one stalled cycle, not eight."""
     eng, events, _ = _engine(monkeypatch, mode=Mode.EXHAUST)
     eng.cfg.timeouts.dhcp_request = 0.01
-    for i in range(5):
+    for cycle in range(4):
         with eng._inflight_lock:
-            eng._inflight[i] = {
-                "mac": "de:ad:00:00:00:01",
-                "sent_at": 0.0,
-                "state": "DISCOVER_SENT",
-            }
+            for i in range(8):
+                eng._inflight[cycle * 8 + i] = {
+                    "mac": "de:ad:00:00:00:01",
+                    "sent_at": 0.0,
+                    "state": "DISCOVER_SENT",
+                }
+        time.sleep(0.02)
+        eng._reap_timeouts()
+        assert eng._halt_signal is None, f"halted after only {cycle + 1} stalled reap(s)"
+    with eng._inflight_lock:
+        eng._inflight[999] = {"mac": "de:ad:00:00:00:01", "sent_at": 0.0, "state": "DISCOVER_SENT"}
     time.sleep(0.02)
     eng._reap_timeouts()
     assert eng._halt_signal is not None
     assert eng._halt_signal[0] == "timeout_storm"
+
+
+def test_timeouts_do_not_accumulate_toward_timeout_storm_once_offers_have_ceased(monkeypatch):
+    """Once offers have already stopped, expiring handshakes is the expected symptom of a
+    drained pool -- offer_silence (§5c) owns that conclusion, not timeout_storm."""
+    eng, _, _ = _engine(monkeypatch, mode=Mode.EXHAUST)
+    eng.cfg.timeouts.dhcp_request = 0.01
+    eng._offers_seen_any = True
+    eng._last_offer_ts = time.time() - 5.0  # quiet well past dhcp_request
+    for cycle in range(6):
+        with eng._inflight_lock:
+            eng._inflight[cycle] = {
+                "mac": "de:ad:00:00:00:01",
+                "sent_at": 0.0,
+                "state": "DISCOVER_SENT",
+            }
+        time.sleep(0.02)
+        eng._reap_timeouts()
+    assert eng._halt_signal is None
+    assert eng._stalled_reaps == 0
 
 
 def _mark_ours(eng, xid: int, mac: str) -> None:

--- a/tests/unit/test_window_headroom.py
+++ b/tests/unit/test_window_headroom.py
@@ -71,6 +71,71 @@ def test_first_offer_wins_later_offers_do_not_override_it(monkeypatch):
     assert est.size == 1022
 
 
+# ---------------------------------------------------------------- observed_span (2.7.3)
+def test_observed_span_needs_at_least_eight_samples(monkeypatch):
+    """A handful of offers must not be mistaken for the whole pool -- below the sample
+    threshold, resolution falls back to the subnet-mask estimate."""
+    eng, _ = _engine(monkeypatch)
+    for i in range(7):
+        eng._note_offer_for_pool_estimate(f"192.168.4.{20 + i}", "255.255.252.0")  # a /22
+    est = eng._estimate_pool()
+    assert est.source == "observed"  # not yet observed_span
+    assert est.size == 1022
+
+
+def test_observed_span_is_a_measured_lower_bound_once_enough_samples_land(monkeypatch):
+    eng, _ = _engine(monkeypatch)
+    for ip in [
+        "192.168.4.20",
+        "192.168.4.25",
+        "192.168.4.30",
+        "192.168.4.35",
+        "192.168.4.40",
+        "192.168.4.45",
+        "192.168.4.50",
+        "192.168.4.60",  # 8th sample, hits the threshold
+    ]:
+        eng._note_offer_for_pool_estimate(ip, "255.255.252.0")  # a /22
+    est = eng._estimate_pool()
+    assert est.source == "observed_span"
+    assert est.is_estimate is True
+    assert est.size == 41  # .20 .. .60 inclusive
+    assert "192.168.4.20" in est.detail and "192.168.4.60" in est.detail
+
+
+def test_observed_span_ignores_addresses_outside_the_first_known_subnet(monkeypatch):
+    """A second scope on the segment must not widen the first scope's span."""
+    eng, _ = _engine(monkeypatch)
+    for i in range(8):
+        eng._note_offer_for_pool_estimate(f"192.168.4.{20 + i}", "255.255.252.0")  # a /22
+    eng._note_offer_for_pool_estimate("10.0.0.200", "255.255.255.0")  # different scope entirely
+    est = eng._estimate_pool()
+    assert est.source == "observed_span"
+    assert est.size == 8  # unwidened by the out-of-subnet address
+
+
+def test_explicit_scope_still_wins_over_an_observed_span(monkeypatch):
+    eng, _ = _engine(monkeypatch, scope_cidrs=["10.0.0.0/29"])  # size 6
+    for i in range(8):
+        eng._note_offer_for_pool_estimate(f"192.168.4.{20 + i}", "255.255.252.0")
+    est = eng._estimate_pool()
+    assert est.source == "scope"
+    assert est.size == 6
+
+
+def test_pool_headroom_low_not_raised_from_an_observed_span_lower_bound(monkeypatch):
+    """observed_span is a lower bound, not the real denominator -- utilization against it would
+    read artificially high and manufacture a finding the network doesn't deserve."""
+    eng, events = _engine(monkeypatch)
+    eng._started = time.time()
+    for i in range(8):
+        eng._note_offer_for_pool_estimate(f"192.168.4.{20 + i}", "255.255.252.0")  # span of 8
+    eng._baseline_neighbor_count = 8  # would read as 100% utilization of the span
+    eng._finalize_findings()
+    ids = [e.finding.id for e in events if isinstance(e, ev.FindingRaised)]
+    assert "POOL_HEADROOM_LOW" not in ids
+
+
 # ---------------------------------------------------------------- headroom
 def test_headroom_is_none_when_the_estimate_is_unknown(monkeypatch):
     eng, _ = _engine(monkeypatch)


### PR DESCRIPTION
## Summary

Nine fixes to the exhaustion verdict path, from a penetration-testing review of `exhaust`. Each one either stops the tool from reporting a wrong verdict or removes something that misled the operator.

- **Deleted `SERVER_STOPPED_SERVING_TEST_CLIENTS`** — a finding whose condition (`post_new.success` while `state == EXHAUSTED`) could never be true outside its own test, which faked the state by hand.
- **Control transactions now retransmit** (`SessionConfig.control_attempts`, default 3) — a single lost DISCOVER/OFFER/ACK used to be able to flip a clean network to a false FAIL, or a genuinely exhausted one to a false "blocked at baseline" PASS. Retried only on "nothing came back"; a NAK stops immediately.
- **Fixed `timeout_storm` firing on a successful drain** — it counted every expired in-flight handshake instead of stalled reap cycles, so a full window emptying at once read as "N consecutive timeouts" and halted before `offer_silence` could report the drain correctly.
- **Foreign OFFERs no longer reset the exhaustion clock** — `_handle_offer()` split into a passive half (server registry, pool estimate) and an owned half (exhaustion counters), gated by xid ownership between them.
- **Pool-size estimate gets a measured lower bound** (`observed_span`) instead of trusting the subnet mask alone, which overestimated a real scope and made `pool_headroom_remaining` the reflexive explanation for any non-result. Excluded from `POOL_HEADROOM_LOW` so it can't manufacture a false positive.
- **Leases that expire mid-run are now counted** and surfaced in evidence, so a short-lease network's own leases lapsing doesn't read as unexplained headroom.
- **The ARP sweep's 1024-host truncation is now reported** instead of silently presenting a partial inventory as the whole segment.
- **`--request-option` now actually changes the DHCP option-55 content sent** — accepted by both builders, honored by neither; also added to `active-scan`.
- **CLI no longer calls `exhaust` "non-destructive"** — it's the most destructive mode in the tool.

## Test plan

- [x] `pytest -m "not integration"` — 410 passed (1 pre-existing, unrelated failure in `test_release_previous.py` present before this branch)
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `mypy src/dhcpig/core` — clean
- [ ] CI (ruff/mypy/pytest matrix across 3.11–3.13, wheel build-check)