### PR TITLE
release: bump version to 2.7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dhcpig"
-version = "2.7.2"
+version = "2.7.3"
 description = "DHCP exhaustion / network-hardening validation tool (whitehat)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/dhcpig/__init__.py
+++ b/src/dhcpig/__init__.py
@@ -1,3 +1,3 @@
 """DHCPig — DHCP exhaustion / network-hardening validation tool (whitehat)."""
 
-__version__ = "2.7.2"
+__version__ = "2.7.3"


### PR DESCRIPTION
## Summary
- Bumps \`pyproject.toml\` and \`dhcpig.__version__\` from 2.7.2 to 2.7.3, matching the \`## 2.7.3\` entry already in CHANGELOG.md (the exhaustion-verdict fixes from #30).

## Test plan
Version bump only; no behavior change.