### PR TITLE
packaging: add dhcpig-web(1), fix stale manpage and README content

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,17 +1,20 @@
 # Packaging
 
-## Debian / Kali `.deb`
+## Debian / Kali
 
-The `debian/` files build a `.deb` that installs the `dhcpig` and `dhcpig-web` console scripts
-plus the desktop launcher under **Applications → 09 Sniffing/Spoofing**.
+**The Debian packaging is not in this repo.** It lives in the Debian Security Tools team's
+git-buildpackage repository:
 
-```bash
-sudo apt install devscripts debhelper dh-python python3-hatchling python3-scapy
-dpkg-buildpackage -us -uc -b
-sudo apt install ../dhcpig_2.0.0_all.deb
-```
+    https://salsa.debian.org/pkg-security-team/dhcpig
 
-Runtime deps are only `python3`, `python3-scapy`, `libpcap0.8` — the web UI is pure stdlib.
+Kali carries no fork of its own — it imports the package from Debian testing — so there is
+nothing separate to file or maintain for Kali.
+
+The `debian/` directory beside this file is a stale leftover that has diverged from what Debian
+actually ships. Don't build from it and don't sync it upstream; use the salsa repository above.
+
+Runtime dependencies of the built package are `python3` and `python3-scapy`. The web UI is pure
+standard library and adds none.
 
 ## PyPI / pipx
 
@@ -19,8 +22,15 @@ Runtime deps are only `python3`, `python3-scapy`, `libpcap0.8` — the web UI is
 pipx install "dhcpig"          # CLI + web UI (web has no extra deps)
 ```
 
+## Manual pages
+
+`dhcpig.1` and `dhcpig-web.1` are shipped here and installed by the Debian package.
+
 ## Desktop launcher
 
-`dhcpig-web.desktop` runs `pkexec dhcpig-web --open` (root is required for raw sockets) and
-appears in the Kali menu under Sniffing/Spoofing. The server stays loopback-bound and prints
-a tokenized URL; the launcher opens the browser to it.
+`dhcpig-web.desktop` runs `pkexec dhcpig-web --open`, since root is required for raw sockets, and
+appears in the Kali menu under Sniffing/Spoofing. The server stays loopback-bound and prints a
+tokenized URL; the launcher opens a browser to it.
+
+Note the `Categories=09-sniffing-spoofing` value is Kali-specific and is not valid under the
+freedesktop menu specification, so Debian ships a corrected copy of this file.

--- a/packaging/dhcpig-web.1
+++ b/packaging/dhcpig-web.1
@@ -1,0 +1,68 @@
+.TH DHCPIG-WEB 1 "2026-08-22" "dhcpig 2.7.3" "User Commands"
+.SH NAME
+dhcpig\-web \- local web user interface for dhcpig
+.SH SYNOPSIS
+.B dhcpig-web
+.RI [ options ]
+.SH DESCRIPTION
+.B dhcpig-web
+starts a small HTTP server presenting a local web interface to
+.BR dhcpig (1):
+a dashboard for launching scans and exhaustion runs, watching traffic, and
+reviewing session reports.
+.PP
+The server uses only the Python standard library. It binds to the loopback
+interface by default and prints a URL containing a randomly generated session
+token; that token is required to reach the interface.
+.PP
+Because the underlying tool sends raw frames,
+.B dhcpig-web
+must run as root. The shipped desktop entry launches it through
+.BR pkexec (1).
+.SH OPTIONS
+.TP
+.BI \-\-bind " ADDRESS"
+Bind to
+.IR ADDRESS .
+Defaults to
+.BR 127.0.0.1 .
+See
+.B SECURITY
+below before changing this.
+.TP
+.BI \-\-port " PORT"
+Listen on
+.IR PORT .
+Defaults to
+.BR 8787 .
+.TP
+.B \-\-open
+Open a browser at the tokenized URL once the server is listening. This is the
+default.
+.TP
+.B \-\-no\-open
+Do not open a browser automatically; print the URL only.
+.TP
+.B \-h ", " \-\-help
+Show a usage summary and exit.
+.SH SECURITY
+The web interface is the control plane for a tool that disrupts a local
+network. Binding it to anything other than a loopback address exposes that
+control plane to every host which can reach the address, guarded only by the
+session token. To reach the interface from another machine, forward a local
+port over SSH instead:
+.PP
+.RS
+.B ssh \-L 8787:127.0.0.1:8787 host
+.RE
+.PP
+A warning is printed when a non-loopback bind address is used.
+.SH EXIT STATUS
+.TP
+.B 0
+The server shut down normally.
+.SH SEE ALSO
+.BR dhcpig (1),
+.BR pkexec (1)
+.SH AUTHOR
+Kevin Amorin.

--- a/packaging/dhcpig.1
+++ b/packaging/dhcpig.1
@@ -1,4 +1,4 @@
-.TH DHCPIG 1 "2026-08-01" "dhcpig 2.5.0" "User Commands"
+.TH DHCPIG 1 "2026-08-22" "dhcpig 2.7.3" "User Commands"
 .SH NAME
 dhcpig \- DHCP exhaustion / network-hardening validation tool (whitehat)
 .SH SYNOPSIS

--- a/packaging/dhcpig.1
+++ b/packaging/dhcpig.1
@@ -57,7 +57,7 @@ fingerprint the DHCP server(s). Non-destructive, but
 .B DESTRUCTIVE.
 DHCPRELEASE every in-scope, ARP-discovered neighbour's lease, re-acquire
 the freed addresses by name (DHCP option 50), then contest ownership of
-what it took with forged ARP conflicts (RFC 5227 \(sc2.4). The pool itself
+what it took with forged ARP conflicts (RFC 5227 section 2.4). The pool itself
 is left intact, so most hosts can immediately get a new address; the
 verdict is whether any host lost its address and failed to get a new one.
 .TP
@@ -159,7 +159,7 @@ has nothing to recover with if this run is interrupted.
 .TP
 .B \-\-no\-evict
 Skip the ARP-conflict eviction phase against re-acquired addresses
-(default: run it). See RFC 5227 \(sc2.4.
+(default: run it). See RFC 5227 section 2.4.
 .TP
 .B \-\-no\-race\-freed
 Skip firing a targeted DISCOVER the moment a live foreign DHCPNAK or


### PR DESCRIPTION
Documentation and packaging metadata only — no Python changes, so `ruff`/`mypy`/`pytest` are unaffected.

## What this fixes

**`dhcpig-web(1)` never existed.** `dhcpig.1` has cross-referenced it since the web UI landed, so that reference has been dangling. Debian had to write and ship its own copy because of it; adding the page here means the cross-reference resolves and Debian can drop theirs.

The new page documents `--bind`, `--port`, `--open`/`--no-open`, and carries a SECURITY section explaining why binding off-loopback exposes the control plane of a Layer-2 attack tool, with the `ssh -L` alternative.

**`dhcpig.1` declared `.TH ... "dhcpig 2.5.0"`** — two releases stale, and visible in `man dhcpig`. Now 2.7.3.

**`dhcpig.1` used `\(sc` (§) in two places.** groff's ASCII device doesn't define that character, so it emitted a warning and silently dropped the glyph — "RFC 5227 2.4" rather than "RFC 5227 §2.4". Spelled out as "section 2.4", which renders on every device.

**`packaging/README.md` was wrong in three ways:** it told users to install `dhcpig_2.0.0_all.deb`, listed `libpcap0.8` as a runtime dependency (Debian dropped it), and pointed at `packaging/debian/` — a stale tree that has diverged from what Debian actually ships. It now points at the real packaging repo at `salsa.debian.org/pkg-security-team/dhcpig` and notes the local `debian/` directory should not be built from.

## Verification

Both manpages are clean under `groff -man -Tascii -ww` and `man --warnings`, checked in a `debian:sid` container, and the rendered output was reviewed. `dhcpig.1` previously warned; it no longer does.

## Not included

`packaging/dhcpig-web.desktop` uses `Categories=09-sniffing-spoofing`, which is Kali-specific and fails `desktop-file-validate` — the other thing Debian currently works around. Left alone deliberately: changing it upstream would cost the Kali menu placement, which is a real tradeoff rather than a cleanup.