### PR TITLE
report: machine-readable verdicts for lab/red-team use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## Unreleased
+
+Four small changes aimed at using DHCPig in a lab exercise or a scripted engagement, where the
+report is handed to someone else and the run's result has to be machine-readable.
+
+- **`--fail-on {fail,inconclusive,never}` carries the verdict in the exit status.** A run that
+  drove a segment to starvation exited `0`, same as one that found nothing, so no scoring script
+  could branch on the outcome. `--fail-on fail` now exits `1` when a `FAIL` finding was raised
+  (`inconclusive` widens that to a broken baseline, which means the segment was never really
+  tested). Default is `never`: exit `0` keeps meaning "the run worked", which is what every
+  existing caller reads it as, and a run that failed to execute keeps its own code (`2`/`3`/`130`)
+  rather than being overwritten.
+- **Findings carry a MITRE ATT&CK technique id.** `Finding.attck`, populated from the catalogue
+  in `core/findings.py` and rendered in the JSON, CSV and HTML reports: `T1498` for the
+  pool-drain findings, `T1557.003` for everything that speaks DHCP for another device (forged
+  RELEASE, option-50 re-acquisition), `T1557.002` for the forged-ARP eviction chain, `T1018` for
+  the neighbour inventory. Controls, recovery and dry-run findings stay unmapped — they describe
+  the tool reporting on itself, not a technique — as does `RUN_SUMMARY`, which is raised by every
+  mode including the read-only scans, so no one static technique is true of it. A test asserts
+  every id in the catalogue is a known technique, so a typo fails CI instead of reaching a report.
+- **The CSV export no longer drops the findings.** It emitted the host inventory alone, so
+  exporting a run for a spreadsheet silently lost every verdict the run existed to produce. It is
+  now two sections in one file — findings (`time,id,verdict,severity,attck,title,summary`), a
+  blank line, then the inventory as before. Findings lead so the verdicts are visible without
+  scrolling past the hosts.
+- **Timestamps for correlating a run against the defender's logs.** Each `Finding` is stamped
+  with `ts` when it is raised, not when the report is rendered (the report is written once at the
+  end, minutes later), and the report header gains `started_at_iso`/`ended_at_iso` alongside the
+  existing epoch floats — UTC, because the operator's timezone is not knowable by whoever reads
+  the report. Shown per finding in the HTML report and in the CSV's `time` column.
+
 ## 2.7.3 — 2026-08-09
 
 Nine fixes to the exhaustion verdict path, from a penetration-testing review of `exhaust`. Each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,15 +21,22 @@ report is handed to someone else and the run's result has to be machine-readable
   mode including the read-only scans, so no one static technique is true of it. A test asserts
   every id in the catalogue is a known technique, so a typo fails CI instead of reaching a report.
 - **The CSV export no longer drops the findings.** It emitted the host inventory alone, so
-  exporting a run for a spreadsheet silently lost every verdict the run existed to produce. It is
-  now two sections in one file — findings (`time,id,verdict,severity,attck,title,summary`), a
-  blank line, then the inventory as before. Findings lead so the verdicts are visible without
-  scrolling past the hosts.
+  exporting a run for a spreadsheet silently lost every verdict the run existed to produce. Both
+  now share one header, discriminated by a leading `section` column
+  (`section,time,id,verdict,severity,attck,title,summary,kind,mac,...`), findings first. One
+  header rather than two stacked ones because two did not fail a strict reader — `csv.DictReader`
+  shifted every inventory row left, putting a MAC under `id` and an IP under `verdict`, and
+  handed back plausible garbage.
 - **Timestamps for correlating a run against the defender's logs.** Each `Finding` is stamped
   with `ts` when it is raised, not when the report is rendered (the report is written once at the
   end, minutes later), and the report header gains `started_at_iso`/`ended_at_iso` alongside the
   existing epoch floats — UTC, because the operator's timezone is not knowable by whoever reads
   the report. Shown per finding in the HTML report and in the CSV's `time` column.
+- **`ended_at` is now the instant the run ended, read from `SessionEnded`, rather than the moment
+  `to_dict()` happened to be called.** The web UI renders a report on download, so the reported
+  run window used to keep growing for as long as nobody downloaded it. Still falls back to "now"
+  for a run that never emitted `SessionEnded` (mid-run, or killed), which is the honest answer
+  there.
 
 ## 2.7.3 — 2026-08-09
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ CLI
 | `--scope CIDR` | bound the targets (repeatable); defaults to the interface's own network |
 | `--rate N` | pps, default 7 — not on `exhaust`, which self-paces |
 | `--no-evict` | skip the ARP-conflict phase |
-| `--report FILE` | write a session report to `FILE` when the run ends; format follows `FILE`'s extension (`.json`/`.csv`/`.html`, default JSON). CSV is two sections: findings, then the host inventory |
+| `--report FILE` | write a session report to `FILE` when the run ends; format follows `FILE`'s extension (`.json`/`.csv`/`.html`, default JSON). CSV carries the findings and the host inventory, one row each, tagged by a `section` column |
 | `--fail-on LEVEL` | exit `1` when a finding at `fail` or `inconclusive` (or worse) was raised, so a lab/CI scoring script can branch on the verdict; default `never` |
 | `--client-mac MAC` | `exhaust` only; use this MAC instead of a random one (repeatable — rotates through the list) |
 | `--request-option SPEC` | `exhaust`/`active-scan`; DHCP option-55 (parameter-request-list) content to send, e.g. `12,14-19,23` (default: the built-in macOS-order profile) |
@@ -111,7 +111,11 @@ evidences (`T1498` network denial of service, `T1557.002`/`T1557.003` ARP and DH
 adversary-in-the-middle) — so a run lines up against the defender's logs and drops into a
 report template without re-deriving either by hand. Scripting a lab exercise:
 
-    sudo dhcpig exhaust eth0 --report run.json --fail-on fail || echo "segment is vulnerable"
+    sudo dhcpig exhaust eth0 --report run.json --fail-on fail
+    [ $? -eq 1 ] && echo "segment is vulnerable"
+
+Test for `1` specifically, not for "non-zero": `2`, `3` and `130` mean the run never completed,
+which is the opposite of a result.
 
 Undoing a run
 -------------

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ CLI
 | `--scope CIDR` | bound the targets (repeatable); defaults to the interface's own network |
 | `--rate N` | pps, default 7 — not on `exhaust`, which self-paces |
 | `--no-evict` | skip the ARP-conflict phase |
-| `--report FILE` | write a session report to `FILE` when the run ends; format follows `FILE`'s extension (`.json`/`.csv`/`.html`, default JSON) |
+| `--report FILE` | write a session report to `FILE` when the run ends; format follows `FILE`'s extension (`.json`/`.csv`/`.html`, default JSON). CSV is two sections: findings, then the host inventory |
+| `--fail-on LEVEL` | exit `1` when a finding at `fail` or `inconclusive` (or worse) was raised, so a lab/CI scoring script can branch on the verdict; default `never` |
 | `--client-mac MAC` | `exhaust` only; use this MAC instead of a random one (repeatable — rotates through the list) |
 | `--request-option SPEC` | `exhaust`/`active-scan`; DHCP option-55 (parameter-request-list) content to send, e.g. `12,14-19,23` (default: the built-in macOS-order profile) |
 | `--no-spoof-eth-src` | `exhaust` only; use the real NIC MAC as the Ethernet source for every frame (Wi-Fi; APs drop frames whose source MAC isn't the associated station) |
@@ -104,6 +105,13 @@ Reading a run
 Everything lands in the event log, worst first: findings, then one line per host, then an
 `OUTCOME` roll-up. `Verbosity 0` (web) or `-v0` (CLI) hides the packet traffic. The JSON export
 is the complete record — the log is a summary.
+
+Every finding carries a UTC timestamp and, where one applies, the MITRE ATT&CK technique it
+evidences (`T1498` network denial of service, `T1557.002`/`T1557.003` ARP and DHCP
+adversary-in-the-middle) — so a run lines up against the defender's logs and drops into a
+report template without re-deriving either by hand. Scripting a lab exercise:
+
+    sudo dhcpig exhaust eth0 --report run.json --fail-on fail || echo "segment is vulnerable"
 
 Undoing a run
 -------------

--- a/packaging/dhcpig.1
+++ b/packaging/dhcpig.1
@@ -102,8 +102,10 @@ when the run ends. Format is chosen from
 extension
 .RI ( .json / .csv / .html ;
 anything else falls back to JSON).
-The CSV export is two sections in one file \- the findings, then a blank
-line, then the host inventory.
+The CSV export carries the run's findings and the host inventory, one row
+each, discriminated by a leading
+.I section
+column.
 .TP
 .BI \-v ", " \-\-verbosity " N"
 Output detail, 0\(en3 (default 2). 0 prints results only (findings and the

--- a/packaging/dhcpig.1
+++ b/packaging/dhcpig.1
@@ -102,6 +102,8 @@ when the run ends. Format is chosen from
 extension
 .RI ( .json / .csv / .html ;
 anything else falls back to JSON).
+The CSV export is two sections in one file \- the findings, then a blank
+line, then the host inventory.
 .TP
 .BI \-v ", " \-\-verbosity " N"
 Output detail, 0\(en3 (default 2). 0 prints results only (findings and the
@@ -113,6 +115,20 @@ Emit a periodic status line with running totals every
 .I SEC
 seconds (default 5; 0 disables it). Shown only at
 .BR \-v3 .
+.TP
+.BI \-\-fail\-on " LEVEL"
+Exit
+.B 1
+when a finding at
+.I LEVEL
+or worse was raised:
+.BR fail ,
+.BR inconclusive ,
+or
+.B never
+(the default). Lets a lab exercise or CI job branch on the verdict. With
+.BR never ,
+the exit status reflects only whether the run itself worked.
 .SS exhaust only
 .TP
 .BI \-\-request\-option " SPEC"
@@ -226,6 +242,11 @@ times as cheap insurance against a dropped frame (default 2).
 .TP
 .B 0
 Success.
+.TP
+.B 1
+The
+.B \-\-fail\-on
+threshold was met. Never returned without that flag.
 .TP
 .B 2
 Bad arguments / configuration error (e.g.

--- a/src/dhcpig/cli/main.py
+++ b/src/dhcpig/cli/main.py
@@ -1,7 +1,7 @@
 """dhcpig command-line interface (V1.0).
 
 Subcommands: exhaust | scan | active-scan | release | release-previous | restore | ifaces | report
-Exit codes: 0 ok · 2 bad args · 3 no DHCP server · 130 interrupted
+Exit codes: 0 ok · 1 --fail-on threshold met · 2 bad args · 3 no DHCP server · 130 interrupted
 """
 
 from __future__ import annotations
@@ -27,6 +27,13 @@ from ..core.reporting import SessionRecorder
 from .render import Renderer
 
 EXIT_OK, EXIT_BADARGS, EXIT_NOSERVER, EXIT_INTERRUPT = 0, 2, 3, 130
+# Opt-in only (--fail-on): by default the exit status says whether the *run* worked, which is
+# what every existing caller reads it as. A lab or CI scoring script asks for the verdict.
+EXIT_FINDING = 1
+
+# Worst-first ordering over Finding.verdict, shared by the "top finding" line and --fail-on.
+_VERDICT_RANK = {"FAIL": 3, "INCONCLUSIVE": 2, "PASS": 1, "INFO": 0}
+_FAIL_ON_RANK = {"fail": _VERDICT_RANK["FAIL"], "inconclusive": _VERDICT_RANK["INCONCLUSIVE"]}
 
 _MODE_BY_CMD = {
     "exhaust": Mode.EXHAUST,
@@ -68,6 +75,14 @@ def build_parser() -> argparse.ArgumentParser:
             default=5.0,
             metavar="SEC",
             help="periodic status line with running stats (default 5s; 0 disables)",
+        )
+        sp.add_argument(
+            "--fail-on",
+            choices=tuple(_FAIL_ON_RANK) + ("never",),
+            default="never",
+            help="exit 1 when a finding at this verdict or worse was raised, so a lab/CI "
+            "scoring script can branch on the result (default: never -- exit status reflects "
+            "only whether the run itself worked)",
         )
 
     ex = sub.add_parser(
@@ -301,7 +316,7 @@ def _cmd_report(path: str) -> int:
     return EXIT_OK
 
 
-def _run_session(cfg: SessionConfig) -> int:
+def _run_session(cfg: SessionConfig, fail_on: str = "never") -> int:
     bus = EventBus()
     recorder = SessionRecorder(cfg)
     renderer = Renderer(verbosity=cfg.verbosity)
@@ -357,10 +372,20 @@ def _run_session(cfg: SessionConfig) -> int:
         f"releases={st['releases']} arp_conflicts={st['arp_conflicts']}"
     )
     if engine.findings:
-        worst = {"FAIL": 3, "INCONCLUSIVE": 2, "PASS": 1, "INFO": 0}
-        top = max(engine.findings, key=lambda f: worst.get(f.verdict, 0))
+        top = max(engine.findings, key=lambda f: _VERDICT_RANK.get(f.verdict, 0))
         print(f"[==] verdict: {top.verdict} — {top.title}")
         print(f"[==] {len(engine.findings)} finding(s); see the report for full evidence")
+        # Only ever *adds* a non-zero status to an otherwise-clean run: a run that already
+        # failed to execute (bad args, no server, interrupted) keeps its own code, which says
+        # something more useful than "a finding was raised".
+        threshold = _FAIL_ON_RANK.get(fail_on)
+        if (
+            rc == EXIT_OK
+            and threshold is not None
+            and _VERDICT_RANK.get(top.verdict, 0) >= threshold
+        ):
+            rc = EXIT_FINDING
+            print(f"[==] exiting {EXIT_FINDING}: --fail-on {fail_on}")
     return rc
 
 
@@ -377,7 +402,7 @@ def main(argv: list[str] | None = None) -> int:
         print("[--] restore complete")
         return EXIT_OK
     cfg = build_config(args)
-    return _run_session(cfg)
+    return _run_session(cfg, fail_on=getattr(args, "fail_on", "never"))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/dhcpig/core/findings.py
+++ b/src/dhcpig/core/findings.py
@@ -16,6 +16,19 @@ from __future__ import annotations
 
 from .models import FAIL, INCONCLUSIVE, INFO, PASS, Finding
 
+# MITRE ATT&CK techniques the findings below evidence: id -> name, so every renderer prints the
+# same wording and a typo'd id in the catalogue fails a test instead of reaching a report. Only
+# techniques a finding actually demonstrates are listed -- this is a mapping for the report a
+# reader hands to a defender, not an attempt to tag the tool as a whole. Two families cover it:
+# the pool-drain findings are a denial of service, and everything that speaks for another device
+# (forged RELEASE, option-50 re-acquisition, forged ARP) is adversary-in-the-middle.
+ATTCK: dict[str, str] = {
+    "T1018": "Remote System Discovery",
+    "T1498": "Network Denial of Service",
+    "T1557.002": "Adversary-in-the-Middle: ARP Cache Poisoning",
+    "T1557.003": "Adversary-in-the-Middle: DHCP Spoofing",
+}
+
 _CATALOG: dict[str, dict] = {
     "RUN_SUMMARY": {
         # recommendation is always overridden per call -- see run_summary_recommendation()
@@ -27,6 +40,7 @@ _CATALOG: dict[str, dict] = {
         "recommendation": "",
     },
     "NEIGHBORS_OBSERVED": {
+        "attck": ["T1018"],
         # title is overridden per call (includes the host count) -- kept here anyway so the
         # catalogue stays the complete list of finding ids.
         "title": "N host(s) were on this segment, and what happened to each",
@@ -74,6 +88,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "DHCP_STARVATION_ATTAINED": {
+        "attck": ["T1498"],
         "title": "A new client was denied an address while spoofed leases were held",
         "verdict": FAIL,
         "severity": "high",
@@ -84,6 +99,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "DHCP_STARVATION_NOT_ATTAINED": {
+        "attck": ["T1498"],
         # recommendation is always overridden per call -- see
         # starvation_not_attained_recommendation() below.
         "title": "A new client could still obtain an address after the run",
@@ -111,6 +127,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "MULTIPLE_DHCP_SERVERS": {
+        "attck": ["T1557.003"],
         "title": "More than one DHCP server answered on this segment",
         "verdict": FAIL,
         "severity": "high",
@@ -120,6 +137,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "FOREIGN_DISCOVERS_UNANSWERED": {
+        "attck": ["T1498"],
         "title": "Other hosts' DHCPDISCOVERs went unanswered during this run",
         "verdict": FAIL,
         "severity": "high",
@@ -131,6 +149,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "FOREIGN_DISCOVERS_ANSWERED": {
+        "attck": ["T1498"],
         "title": "Other hosts' DHCPDISCOVERs were all answered during this run",
         "verdict": INFO,
         "severity": "info",
@@ -140,6 +159,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "CLIENTS_EVICTED_FROM_ADDRESSES": {
+        "attck": ["T1557.002"],
         "title": "ARP-conflict eviction forced clients off their addresses",
         "verdict": FAIL,
         "severity": "high",
@@ -156,6 +176,7 @@ _CATALOG: dict[str, dict] = {
     # disjoint sets of hosts, so a run that evicts two targets and leaves a third sitting on a
     # binding we now own has two separate things to report, not one to choose between.
     "CLIENTS_HOLDING_STOLEN_LEASES": {
+        "attck": ["T1557.003"],
         "title": "Targets held addresses the server had already reassigned to us",
         "verdict": FAIL,
         "severity": "high",
@@ -171,6 +192,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "CLIENTS_DEFENDED_ADDRESSES": {
+        "attck": ["T1557.002"],
         "title": "Targets reacted to the ARP conflict but were not denied service",
         "verdict": INCONCLUSIVE,
         "severity": "medium",
@@ -185,6 +207,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "ARP_CONFLICTS_UNANSWERED": {
+        "attck": ["T1557.002"],
         "title": "ARP-conflict frames drew no reaction from any target",
         "verdict": INCONCLUSIVE,
         "severity": "medium",
@@ -195,6 +218,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "RACED_FREED_ADDRESSES": {
+        "attck": ["T1557.003"],
         "title": "Raced to re-acquire addresses as soon as they were observed freed",
         "verdict": INFO,
         "severity": "info",
@@ -209,6 +233,7 @@ _CATALOG: dict[str, dict] = {
         ),
     },
     "NEIGHBOR_LEASES_RELEASED": {
+        "attck": ["T1557.003"],
         # recommendation is always overridden per call -- see
         # neighbor_leases_released_recommendation() below.
         "title": "Sent DHCPRELEASE for ARP-discovered neighbors, then re-acquired them",
@@ -291,7 +316,16 @@ def build(
         severity=entry["severity"],
         evidence=evidence,
         recommendation=(recommendation if recommendation is not None else entry["recommendation"]),
+        attck=list(entry.get("attck", ())),
     )
+
+
+def attck_labels(ids) -> list[str]:
+    """`["T1557.003"]` -> `["T1557.003 Adversary-in-the-Middle: DHCP Spoofing"]`, for display.
+
+    An id absent from `ATTCK` renders bare rather than raising -- a report is not the place to
+    discover a typo. `test_findings_attck` is; it asserts every id in the catalogue is known."""
+    return [f"{i} {ATTCK[i]}" if i in ATTCK else str(i) for i in ids or ()]
 
 
 def run_summary_recommendation(mode: str) -> str:

--- a/src/dhcpig/core/findings.py
+++ b/src/dhcpig/core/findings.py
@@ -16,12 +16,24 @@ from __future__ import annotations
 
 from .models import FAIL, INCONCLUSIVE, INFO, PASS, Finding
 
-# MITRE ATT&CK techniques the findings below evidence: id -> name, so every renderer prints the
-# same wording and a typo'd id in the catalogue fails a test instead of reaching a report. Only
-# techniques a finding actually demonstrates are listed -- this is a mapping for the report a
-# reader hands to a defender, not an attempt to tag the tool as a whole. Two families cover it:
-# the pool-drain findings are a denial of service, and everything that speaks for another device
+# MITRE ATT&CK techniques, id -> name, so every renderer prints the same wording and a typo'd id
+# in the catalogue fails a test instead of reaching a report. Two families cover it: the
+# pool-drain findings are a denial of service, and everything that speaks for another device
 # (forged RELEASE, option-50 re-acquisition, forged ARP) is adversary-in-the-middle.
+#
+# **A finding is tagged with the technique it ASSESSES, not with a claim that the technique
+# worked** -- so `DHCP_STARVATION_NOT_ATTAINED` (PASS) carries T1498 exactly as
+# `DHCP_STARVATION_ATTAINED` (FAIL) does. That is deliberate, and load-bearing: the point of the
+# mapping is a report row saying "we attempted T1498, here is what the network did", and a
+# defender mapping their coverage needs the technique that was tested and held just as much as
+# the one that succeeded. Dropping it from the PASS findings would make the report able to
+# express only failures. Always read the `attck` column with `verdict` beside it -- every
+# renderer emits the two together, and `test_findings_attck.py` pins that pairing so this is not
+# quietly "corrected" later.
+#
+# Findings that assess no technique at all stay unmapped: controls, recovery and dry runs are the
+# tool reporting on itself. So is RUN_SUMMARY -- raised by every mode including the read-only
+# scans, so no one static technique is true of it.
 ATTCK: dict[str, str] = {
     "T1018": "Remote System Discovery",
     "T1498": "Network Denial of Service",

--- a/src/dhcpig/core/models.py
+++ b/src/dhcpig/core/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -326,3 +327,10 @@ class Finding:
     severity: str  # info | low | medium | high
     evidence: dict = field(default_factory=dict)
     recommendation: str = ""
+    # MITRE ATT&CK technique ids this finding evidences; `findings.ATTCK` maps id -> name.
+    # Empty for findings that describe no adversary behaviour (controls, recovery, dry runs).
+    attck: list[str] = field(default_factory=list)
+    # Wall-clock time the conclusion was reached, so a run can be lined up against the
+    # defender's logs. Stamped at construction (findings.build()), not at report-render time --
+    # the report is written once at the end, minutes after the finding was actually true.
+    ts: float = field(default_factory=time.time)

--- a/src/dhcpig/core/models.py
+++ b/src/dhcpig/core/models.py
@@ -327,8 +327,9 @@ class Finding:
     severity: str  # info | low | medium | high
     evidence: dict = field(default_factory=dict)
     recommendation: str = ""
-    # MITRE ATT&CK technique ids this finding evidences; `findings.ATTCK` maps id -> name.
-    # Empty for findings that describe no adversary behaviour (controls, recovery, dry runs).
+    # MITRE ATT&CK technique ids this finding assesses -- not a claim the technique succeeded;
+    # a PASS finding carries the technique it tested for. Read with `verdict`. See findings.ATTCK.
+    # Empty for findings that assess no technique (controls, recovery, dry runs).
     attck: list[str] = field(default_factory=list)
     # Wall-clock time the conclusion was reached, so a run can be lined up against the
     # defender's logs. Stamped at construction (findings.build()), not at report-render time --

--- a/src/dhcpig/core/reporting.py
+++ b/src/dhcpig/core/reporting.py
@@ -5,14 +5,31 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import asdict
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 
 from .. import __version__
 from . import events as ev
-from .findings import EVIDENCE_SKIP, finding_summary_lines  # noqa: F401 -- re-exported below
+from .findings import (  # noqa: F401 -- EVIDENCE_SKIP re-exported below
+    EVIDENCE_SKIP,
+    attck_labels,
+    finding_summary_lines,
+)
 from .fingerprint import DB_VERSION
 from .models import SessionConfig
+
+
+def _iso(ts: float | None) -> str:
+    """Epoch seconds -> UTC ISO-8601. Empty for a missing/zero timestamp.
+
+    UTC rather than local time, and alongside the raw epoch rather than replacing it: the point
+    of the string is pasting it into someone else's log search, where the operator's timezone is
+    not knowable and an ambiguous local timestamp is worse than none.
+    """
+    if not ts:
+        return ""
+    return datetime.fromtimestamp(ts, tz=UTC).isoformat(timespec="seconds")
 
 
 def _json_default(o):
@@ -80,6 +97,7 @@ class SessionRecorder:
     def to_dict(self) -> dict:
         # jsonable() converts any nested enums/bytes so the web /api/report path (plain
         # json.dumps) and the file export both work.
+        ended = time.time()
         return ev.jsonable(
             {
                 "tool": "dhcpig",
@@ -87,7 +105,13 @@ class SessionRecorder:
                 "interface": self.cfg.interface,
                 "mode": self.cfg.mode.value,
                 "started_at": self.started,
-                "ended_at": time.time(),
+                "ended_at": ended,
+                # Same two instants as strings. Every consumer that had the epochs still has
+                # them; these are for the human correlating the run against switch/DHCP logs,
+                # who should not have to convert a float by hand. Per-finding times live on
+                # each finding's own `ts` (models.Finding).
+                "started_at_iso": _iso(self.started),
+                "ended_at_iso": _iso(ended),
                 "config": self._config_redacted(),
                 "scope_cidrs": self.cfg.scope_cidrs,
                 "fingerprint_db": DB_VERSION,
@@ -196,16 +220,44 @@ def _flat_rows(data: dict) -> list[dict]:
     return rows
 
 
+_FINDING_COLS = ["time", "id", "verdict", "severity", "attck", "title", "summary"]
+_INVENTORY_COLS = ["kind", "mac", "ip", "server_id", "os", "device", "vendor", "confidence"]
+
+
 def _to_csv(data: dict) -> str:
+    """Two sections in one file -- findings first, then the inventory, separated by a blank line.
+
+    The findings section is why anyone opens the export: this used to emit the inventory alone,
+    so exporting a run to CSV for a spreadsheet silently dropped every verdict the run existed to
+    produce. The two have no columns in common, hence two headers rather than one padded schema.
+    Spreadsheets import this as written; a strict reader should split on the blank line and parse
+    each half. Findings lead so the verdicts are visible without scrolling past the hosts.
+    """
     import csv
     import io
 
-    cols = ["kind", "mac", "ip", "server_id", "os", "device", "vendor", "confidence"]
     buf = io.StringIO()
-    w = csv.DictWriter(buf, fieldnames=cols)
+    w = csv.DictWriter(buf, fieldnames=_FINDING_COLS, lineterminator="\r\n")
+    w.writeheader()
+    for f in data.get("findings", []):
+        w.writerow(
+            {
+                "time": _iso(f.get("ts")),
+                "id": f.get("id", ""),
+                "verdict": f.get("verdict", ""),
+                "severity": f.get("severity", ""),
+                "attck": " ".join(f.get("attck") or []),
+                "title": f.get("title", ""),
+                # The same summary the log and the HTML report show, flattened onto one cell --
+                # the full evidence stays in the JSON export, which is what it is for.
+                "summary": " | ".join(finding_summary_lines(f)),
+            }
+        )
+    buf.write("\r\n")
+    w = csv.DictWriter(buf, fieldnames=_INVENTORY_COLS, lineterminator="\r\n")
     w.writeheader()
     for row in _flat_rows(data):
-        w.writerow({c: row.get(c, "") for c in cols})
+        w.writerow({c: row.get(c, "") for c in _INVENTORY_COLS})
     return buf.getvalue()
 
 
@@ -227,6 +279,11 @@ def _findings_html(data: dict) -> str:
     for f in findings:
         verdict = str(f.get("verdict", ""))
         body = "".join(f'<div class="ev">{escape(line)}</div>' for line in finding_summary_lines(f))
+        # When it was concluded, and which adversary technique it evidences -- the two things a
+        # reader needs to line this up against a defender's logs and their own reporting.
+        meta = " · ".join(x for x in (_iso(f.get("ts")), *attck_labels(f.get("attck"))) if x)
+        if meta:
+            body += f'<div class="meta">{escape(meta)}</div>'
         out.append(
             f'<div class="finding"><span class="v" style="background:'
             f'{colors.get(verdict, "#555")}">{escape(verdict)}</span> '
@@ -300,7 +357,8 @@ font-size:13px;text-align:left}}th{{background:#f2f2f2}}
 .finding .v{{color:#fff;padding:1px 7px;border-radius:3px;font-size:11px;font-weight:700}}
 .finding code{{color:#666;font-size:11px}}
 .finding .ev{{font-size:12px;color:#444;margin-top:4px;font-family:ui-monospace,monospace}}
-.finding .rec{{font-size:12px;color:#666;margin-top:4px}}</style></head><body>
+.finding .rec{{font-size:12px;color:#666;margin-top:4px}}
+.finding .meta{{font-size:11px;color:#777;margin-top:4px}}</style></head><body>
 <h1>DHCPig report</h1>
 <p><b>Interface:</b> {escape(str(data.get("interface")))} &nbsp;
 <b>Mode:</b> {escape(str(data.get("mode")))} &nbsp;
@@ -308,6 +366,9 @@ font-size:13px;text-align:left}}th{{background:#f2f2f2}}
 (confirmed: {escape(str(data.get("pool_exhaustion_confirmed")))}) &nbsp;
 <b>Scope:</b> {escape(str(data.get("scope_cidrs")))} &nbsp;
 <b>Fingerprint DB:</b> {escape(str(data.get("fingerprint_db")))}</p>
+<p style="font-size:12px;color:#666"><b>Run window (UTC):</b>
+{escape(str(data.get("started_at_iso", "")))} &rarr;
+{escape(str(data.get("ended_at_iso", "")))}</p>
 {_pool_estimate_line(data)}
 <h2>Findings</h2>
 {_findings_html(data)}

--- a/src/dhcpig/core/reporting.py
+++ b/src/dhcpig/core/reporting.py
@@ -61,6 +61,11 @@ class SessionRecorder:
         self.exhausted = False
         self.exhaustion_confirmed = False
         self.final_status: dict = {}
+        # When the run actually ended, taken from SessionEnded (engine.py emits it last, right
+        # after state = DONE). None until then, and to_dict() falls back to "now" -- but it must
+        # not *prefer* now: the web UI renders a report on download, so a report fetched half an
+        # hour after the run would otherwise claim a half-hour-longer run window.
+        self.ended: float | None = None
 
     def handle(self, event: ev.Event) -> None:
         if isinstance(event, ev.ServerDiscovered):
@@ -85,6 +90,7 @@ class SessionRecorder:
                 self.exhaustion_confirmed = True
         elif isinstance(event, ev.SessionEnded):
             self.final_status = event.report
+            self.ended = time.time()
 
     def _config_redacted(self) -> dict:
         d = asdict(self.cfg)
@@ -97,7 +103,7 @@ class SessionRecorder:
     def to_dict(self) -> dict:
         # jsonable() converts any nested enums/bytes so the web /api/report path (plain
         # json.dumps) and the file export both work.
-        ended = time.time()
+        ended = self.ended if self.ended is not None else time.time()
         return ev.jsonable(
             {
                 "tool": "dhcpig",
@@ -222,26 +228,32 @@ def _flat_rows(data: dict) -> list[dict]:
 
 _FINDING_COLS = ["time", "id", "verdict", "severity", "attck", "title", "summary"]
 _INVENTORY_COLS = ["kind", "mac", "ip", "server_id", "os", "device", "vendor", "confidence"]
+# One header over the union of both, discriminated by `section`. Two stacked headers (findings,
+# blank line, inventory) read fine in a spreadsheet but are a trap for every other consumer:
+# csv.DictReader doesn't fail on the second header, it silently shifts every inventory row left
+# -- a MAC lands in `id`, an IP in `verdict` -- and hands back plausible garbage. Empty cells are
+# a much cheaper price than a report someone believes and shouldn't.
+_CSV_COLS = ["section", *_FINDING_COLS, *_INVENTORY_COLS]
 
 
 def _to_csv(data: dict) -> str:
-    """Two sections in one file -- findings first, then the inventory, separated by a blank line.
+    """Findings then inventory, one row each, `section` saying which.
 
-    The findings section is why anyone opens the export: this used to emit the inventory alone,
-    so exporting a run to CSV for a spreadsheet silently dropped every verdict the run existed to
-    produce. The two have no columns in common, hence two headers rather than one padded schema.
-    Spreadsheets import this as written; a strict reader should split on the blank line and parse
-    each half. Findings lead so the verdicts are visible without scrolling past the hosts.
+    The findings half is why anyone opens the export: this used to emit the inventory alone, so
+    exporting a run to CSV for a spreadsheet silently dropped every verdict the run existed to
+    produce. Findings lead so the verdicts are visible without scrolling past the hosts; filter
+    or pivot on `section` to get one kind back on its own.
     """
     import csv
     import io
 
     buf = io.StringIO()
-    w = csv.DictWriter(buf, fieldnames=_FINDING_COLS, lineterminator="\r\n")
+    w = csv.DictWriter(buf, fieldnames=_CSV_COLS, extrasaction="ignore")
     w.writeheader()
     for f in data.get("findings", []):
         w.writerow(
             {
+                "section": "finding",
                 "time": _iso(f.get("ts")),
                 "id": f.get("id", ""),
                 "verdict": f.get("verdict", ""),
@@ -253,11 +265,8 @@ def _to_csv(data: dict) -> str:
                 "summary": " | ".join(finding_summary_lines(f)),
             }
         )
-    buf.write("\r\n")
-    w = csv.DictWriter(buf, fieldnames=_INVENTORY_COLS, lineterminator="\r\n")
-    w.writeheader()
     for row in _flat_rows(data):
-        w.writerow({c: row.get(c, "") for c in _INVENTORY_COLS})
+        w.writerow({"section": "inventory", **row})
     return buf.getvalue()
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -234,9 +234,9 @@ def test_report_path_extension_selects_the_written_format(tmp_path, monkeypatch)
         interface="lo", mode=Mode.RELEASE_NEIGHBORS, offline=True, report_path=csv_path
     )
     assert cli._run_session(cfg) == cli.EXIT_OK
-    assert csv_path.read_text().splitlines()[0] == (
-        "kind,mac,ip,server_id,os,device,vendor,confidence"
-    )
+    csv_lines = csv_path.read_text().splitlines()
+    assert csv_lines[0] == "time,id,verdict,severity,attck,title,summary"
+    assert "kind,mac,ip,server_id,os,device,vendor,confidence" in csv_lines
 
     html_path = tmp_path / "run.html"
     cfg = SessionConfig(
@@ -278,3 +278,61 @@ def test_exhaust_accepts_scope_so_copy_as_cli_round_trips():
     assert "--scope 192.168.4.0/22" in cmd
     args = cli.build_parser().parse_args(shlex.split(cmd)[1:])  # must not SystemExit
     assert cli.build_config(args).scope_cidrs == ["192.168.4.0/22"]
+
+
+class _StubEngine:
+    """Minimal stand-in for DhcpEngine, exposing only what _run_session() touches.
+
+    --fail-on is pure exit-code logic over the findings a run ended with, so these state the
+    findings directly rather than contriving a live run that happens to raise them.
+    """
+
+    def __init__(self, findings):
+        self.findings = findings
+        self.state = engine_mod.DONE
+        self.discovers, self.servers, self._threads = [], [], []
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def status(self):
+        return dict.fromkeys(("leases", "servers", "naks", "releases", "arp_conflicts"), 0)
+
+
+def _rc_for(monkeypatch, verdicts, fail_on):
+    from dhcpig.core.models import Finding
+
+    findings = [Finding(id="X", title="t", verdict=v, severity="high") for v in verdicts]
+    monkeypatch.setattr(cli, "DhcpEngine", lambda cfg, bus: _StubEngine(findings))
+    cfg = SessionConfig(interface="lo", mode=Mode.RELEASE_NEIGHBORS, offline=True)
+    return cli._run_session(cfg, fail_on=fail_on)
+
+
+def test_fail_on_defaults_to_never_so_a_fail_finding_still_exits_zero(monkeypatch):
+    """Exit 0 has always meant "the run worked", and every existing caller reads it that way.
+    Carrying the verdict in the exit status is opt-in, never the default."""
+    assert _rc_for(monkeypatch, ["FAIL"], "never") == cli.EXIT_OK
+
+
+def test_fail_on_fail_exits_one_so_a_scoring_script_can_branch(monkeypatch):
+    assert _rc_for(monkeypatch, ["INFO", "FAIL"], "fail") == cli.EXIT_FINDING
+    assert _rc_for(monkeypatch, ["INFO", "PASS"], "fail") == cli.EXIT_OK
+
+
+def test_fail_on_inconclusive_is_the_wider_threshold(monkeypatch):
+    """An inconclusive run is a result a lab wants to catch -- usually a broken baseline, which
+    means the segment was never actually tested. --fail-on fail deliberately lets it pass."""
+    assert _rc_for(monkeypatch, ["INCONCLUSIVE"], "inconclusive") == cli.EXIT_FINDING
+    assert _rc_for(monkeypatch, ["INCONCLUSIVE"], "fail") == cli.EXIT_OK
+    assert _rc_for(monkeypatch, ["FAIL"], "inconclusive") == cli.EXIT_FINDING
+
+
+def test_fail_on_parses_on_every_mode_and_defaults_to_never():
+    for cmd in ("exhaust", "scan", "active-scan", "release", "release-previous"):
+        assert cli.build_parser().parse_args([cmd, "eth1"]).fail_on == "never"
+    assert cli.build_parser().parse_args(["exhaust", "eth1", "--fail-on", "fail"]).fail_on == "fail"
+    with pytest.raises(SystemExit):  # not a free-form string
+        cli.build_parser().parse_args(["exhaust", "eth1", "--fail-on", "high"])

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -234,9 +234,10 @@ def test_report_path_extension_selects_the_written_format(tmp_path, monkeypatch)
         interface="lo", mode=Mode.RELEASE_NEIGHBORS, offline=True, report_path=csv_path
     )
     assert cli._run_session(cfg) == cli.EXIT_OK
-    csv_lines = csv_path.read_text().splitlines()
-    assert csv_lines[0] == "time,id,verdict,severity,attck,title,summary"
-    assert "kind,mac,ip,server_id,os,device,vendor,confidence" in csv_lines
+    assert csv_path.read_text().splitlines()[0] == (
+        "section,time,id,verdict,severity,attck,title,summary,"
+        "kind,mac,ip,server_id,os,device,vendor,confidence"
+    )
 
     html_path = tmp_path / "run.html"
     cfg = SessionConfig(

--- a/tests/unit/test_findings_attck.py
+++ b/tests/unit/test_findings_attck.py
@@ -19,6 +19,10 @@ def test_build_carries_the_mapping_onto_the_finding():
     assert build("CLIENTS_EVICTED_FROM_ADDRESSES", {}).attck == ["T1557.002"]  # forged ARP
     assert build("DHCP_STARVATION_ATTAINED", {}).attck == ["T1498"]  # pool drained
     assert build("NEIGHBOR_LEASES_RELEASED", {}).attck == ["T1557.003"]  # spoken for elsewhere
+    # The mapping says which technique a finding ASSESSES, not that it succeeded -- so the PASS
+    # finding carries the same id as the FAIL one. Deliberate and easy to mistake for a bug:
+    # dropping it would leave the report able to express only failures. See findings.ATTCK.
+    assert build("DHCP_STARVATION_NOT_ATTAINED", {}).attck == ["T1498"]  # PASS, same technique
 
 
 def test_findings_that_describe_no_adversary_behaviour_are_unmapped():

--- a/tests/unit/test_findings_attck.py
+++ b/tests/unit/test_findings_attck.py
@@ -1,0 +1,37 @@
+"""MITRE ATT&CK mapping on the finding catalogue.
+
+The mapping exists so a report drops straight into someone else's reporting template without a
+human re-deriving "which technique was that". Its whole value is being right, so the integrity
+check below (every id in the catalogue is a known technique) is the point of this file -- a
+typo'd id would otherwise reach a report and be believed.
+"""
+
+from dhcpig.core.findings import _CATALOG, ATTCK, attck_labels, build
+
+
+def test_every_catalogued_technique_id_is_known():
+    for fid, entry in _CATALOG.items():
+        for tid in entry.get("attck", ()):
+            assert tid in ATTCK, f"{fid} maps to unknown technique {tid}"
+
+
+def test_build_carries_the_mapping_onto_the_finding():
+    assert build("CLIENTS_EVICTED_FROM_ADDRESSES", {}).attck == ["T1557.002"]  # forged ARP
+    assert build("DHCP_STARVATION_ATTAINED", {}).attck == ["T1498"]  # pool drained
+    assert build("NEIGHBOR_LEASES_RELEASED", {}).attck == ["T1557.003"]  # spoken for elsewhere
+
+
+def test_findings_that_describe_no_adversary_behaviour_are_unmapped():
+    """Controls, recovery and dry runs are the tool reporting on itself, not a technique.
+    RUN_SUMMARY is unmapped for a different reason: it is raised by every mode including the
+    read-only scans, so no single static technique is true of it."""
+    for fid in ("RUN_SUMMARY", "CONTROL_BASELINE_FAILED", "POOL_RECOVERED", "DRY_RUN_SUMMARY"):
+        assert build(fid, {}).attck == []
+
+
+def test_attck_labels_names_known_ids_and_passes_unknown_through():
+    assert attck_labels(["T1557.003"]) == [
+        "T1557.003 Adversary-in-the-Middle: DHCP Spoofing",
+    ]
+    assert attck_labels(["T9999"]) == ["T9999"]  # a report is no place to raise on a typo
+    assert attck_labels(None) == []

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -2,6 +2,7 @@ import json
 
 from dhcpig import __version__
 from dhcpig.core import events as ev
+from dhcpig.core.findings import build
 from dhcpig.core.models import HostFingerprint, IPVersion, Lease, Neighbor, SessionConfig
 from dhcpig.core.reporting import SessionRecorder
 
@@ -82,11 +83,14 @@ def _recorder_with_data():
 
 
 def test_render_csv():
+    """Two sections: findings first, then the inventory. The findings half used to be missing
+    entirely, so a CSV export dropped every verdict the run existed to produce."""
     text, ctype = _recorder_with_data().render("csv")
     assert ctype == "text/csv"
     lines = text.strip().splitlines()
-    assert lines[0] == "kind,mac,ip,server_id,os,device,vendor,confidence"
-    assert any(row.startswith("lease,de:ad:00:00:00:01,10.0.0.5") for row in lines[1:])
+    assert lines[0] == "time,id,verdict,severity,attck,title,summary"
+    assert "kind,mac,ip,server_id,os,device,vendor,confidence" in lines
+    assert any(row.startswith("lease,de:ad:00:00:00:01,10.0.0.5") for row in lines)
 
 
 def test_render_html():
@@ -100,3 +104,43 @@ def test_render_bad_format():
 
     with pytest.raises(ValueError):
         _recorder_with_data().render("pdf")
+
+
+def test_report_carries_iso_timestamps_alongside_the_epochs():
+    """The epochs stay (existing consumers read them); the strings are for the human lining a
+    run up against switch/DHCP-server logs, who should not convert a float by hand."""
+    data = SessionRecorder(SessionConfig(interface="eth1")).to_dict()
+    assert data["started_at_iso"].endswith("+00:00")  # UTC, not an ambiguous local time
+    assert data["ended_at_iso"] >= data["started_at_iso"]
+    assert isinstance(data["started_at"], float) and isinstance(data["ended_at"], float)
+
+
+def _recorder_with_a_finding():
+    rec = SessionRecorder(SessionConfig(interface="eth1"))
+    rec.handle(ev.FindingRaised(finding=build("CLIENTS_EVICTED_FROM_ADDRESSES", {"evicted": 2})))
+    return rec
+
+
+def test_csv_findings_section_carries_time_verdict_and_attck():
+    lines = _recorder_with_a_finding().render("csv")[0].splitlines()
+    assert lines[0] == "time,id,verdict,severity,attck,title,summary"
+    row = next(ln for ln in lines if ln.startswith("20"))  # the ISO timestamp leads the row
+    assert "CLIENTS_EVICTED_FROM_ADDRESSES,FAIL,high,T1557.002" in row
+    assert "+00:00" in row
+
+
+def test_html_finding_shows_when_it_was_concluded_and_which_technique_it_evidences():
+    text = _recorder_with_a_finding().render("html")[0]
+    assert "T1557.002 Adversary-in-the-Middle: ARP Cache Poisoning" in text
+    assert "Run window (UTC)" in text
+
+
+def test_finding_timestamp_is_stamped_when_raised_not_when_rendered():
+    """A report is written once at the end, minutes after a finding was actually true --
+    rendering must not be able to restate when it happened."""
+    import time
+
+    f = build("DHCP_NAK_OBSERVED", {})
+    time.sleep(0.01)
+    data = SessionRecorder(SessionConfig(interface="eth1")).to_dict()
+    assert f.ts < data["ended_at"]

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 from dhcpig import __version__
 from dhcpig.core import events as ev
@@ -83,14 +84,16 @@ def _recorder_with_data():
 
 
 def test_render_csv():
-    """Two sections: findings first, then the inventory. The findings half used to be missing
-    entirely, so a CSV export dropped every verdict the run existed to produce."""
+    """Findings and inventory under one header, tagged by `section`. The findings half used to be
+    missing entirely, so a CSV export dropped every verdict the run existed to produce."""
     text, ctype = _recorder_with_data().render("csv")
     assert ctype == "text/csv"
     lines = text.strip().splitlines()
-    assert lines[0] == "time,id,verdict,severity,attck,title,summary"
-    assert "kind,mac,ip,server_id,os,device,vendor,confidence" in lines
-    assert any(row.startswith("lease,de:ad:00:00:00:01,10.0.0.5") for row in lines)
+    assert lines[0] == (
+        "section,time,id,verdict,severity,attck,title,summary,"
+        "kind,mac,ip,server_id,os,device,vendor,confidence"
+    )
+    assert any(",lease,de:ad:00:00:00:01,10.0.0.5" in row for row in lines[1:])
 
 
 def test_render_html():
@@ -106,13 +109,31 @@ def test_render_bad_format():
         _recorder_with_data().render("pdf")
 
 
-def test_report_carries_iso_timestamps_alongside_the_epochs():
-    """The epochs stay (existing consumers read them); the strings are for the human lining a
-    run up against switch/DHCP-server logs, who should not convert a float by hand."""
-    data = SessionRecorder(SessionConfig(interface="eth1")).to_dict()
-    assert data["started_at_iso"].endswith("+00:00")  # UTC, not an ambiguous local time
-    assert data["ended_at_iso"] >= data["started_at_iso"]
-    assert isinstance(data["started_at"], float) and isinstance(data["ended_at"], float)
+def test_report_timestamps_belong_to_the_run_not_the_render():
+    """Three things at once, because they are one behaviour: the epochs keep their existing
+    consumers and gain UTC strings for the human correlating against switch/DHCP logs; a
+    finding is stamped when raised and stays stamped through rendering; and `ended_at` comes
+    from SessionEnded, so the web UI rendering a report on download cannot restate the run's
+    end as the download time. Falls back to "now" only for a run that never ended."""
+    rec = SessionRecorder(SessionConfig(interface="eth1"))
+
+    assert rec.ended is None  # mid-run / killed run: "now" is the honest answer
+    assert rec.to_dict()["ended_at"] >= rec.started
+
+    f = build("DHCP_NAK_OBSERVED", {})
+    f.ts = 1_000_000_000.0  # 2001-09-09, unmistakably not the render time
+    rec.handle(ev.FindingRaised(finding=f))
+    rec.handle(ev.SessionEnded(report={}))
+
+    first = rec.to_dict()
+    assert first["started_at_iso"].endswith("+00:00")  # UTC, not an ambiguous local time
+    assert isinstance(first["started_at"], float) and isinstance(first["ended_at"], float)
+    assert first["findings"][0]["ts"] == 1_000_000_000.0
+    assert "2001-09-09" in rec.render("csv")[0] and "2001-09-09" in rec.render("html")[0]
+
+    time.sleep(0.05)
+    later = rec.to_dict()
+    assert (first["ended_at"], first["ended_at_iso"]) == (later["ended_at"], later["ended_at_iso"])
 
 
 def _recorder_with_a_finding():
@@ -121,12 +142,11 @@ def _recorder_with_a_finding():
     return rec
 
 
-def test_csv_findings_section_carries_time_verdict_and_attck():
+def test_csv_finding_rows_carry_time_verdict_and_attck():
     lines = _recorder_with_a_finding().render("csv")[0].splitlines()
-    assert lines[0] == "time,id,verdict,severity,attck,title,summary"
-    row = next(ln for ln in lines if ln.startswith("20"))  # the ISO timestamp leads the row
+    row = next(ln for ln in lines if ln.startswith("finding,"))
     assert "CLIENTS_EVICTED_FROM_ADDRESSES,FAIL,high,T1557.002" in row
-    assert "+00:00" in row
+    assert "+00:00" in row  # the ISO timestamp, not a bare epoch float
 
 
 def test_html_finding_shows_when_it_was_concluded_and_which_technique_it_evidences():
@@ -135,12 +155,19 @@ def test_html_finding_shows_when_it_was_concluded_and_which_technique_it_evidenc
     assert "Run window (UTC)" in text
 
 
-def test_finding_timestamp_is_stamped_when_raised_not_when_rendered():
-    """A report is written once at the end, minutes after a finding was actually true --
-    rendering must not be able to restate when it happened."""
-    import time
+def test_csv_is_parseable_by_a_strict_reader():
+    """Findings and inventory share one header, discriminated by `section`. The earlier
+    two-stacked-headers form did not fail a csv.DictReader -- it silently shifted every
+    inventory row left, putting a MAC under `id` and an IP under `verdict`."""
+    import csv
+    import io
 
-    f = build("DHCP_NAK_OBSERVED", {})
-    time.sleep(0.01)
-    data = SessionRecorder(SessionConfig(interface="eth1")).to_dict()
-    assert f.ts < data["ended_at"]
+    rec = _recorder_with_data()  # one lease
+    rec.handle(ev.FindingRaised(finding=build("CLIENTS_EVICTED_FROM_ADDRESSES", {"evicted": 2})))
+    rows = list(csv.DictReader(io.StringIO(rec.render("csv")[0])))
+    assert [r["section"] for r in rows] == ["finding", "inventory"]
+    finding, inventory = rows
+    assert finding["id"] == "CLIENTS_EVICTED_FROM_ADDRESSES" and finding["verdict"] == "FAIL"
+    assert not finding["mac"]  # a finding's cells never bleed into the inventory columns
+    assert inventory["kind"] == "lease" and inventory["mac"] == "de:ad:00:00:00:01"
+    assert not inventory["verdict"]  # ... and vice versa: no IP masquerading as a verdict

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -152,7 +152,9 @@ def test_report_download_csv(server):
     assert r.status == 200
     assert r.getheader("Content-Type") == "text/csv"
     assert "attachment" in (r.getheader("Content-Disposition") or "")
-    assert body.splitlines()[0] == "kind,mac,ip,server_id,os,device,vendor,confidence"
+    lines = body.splitlines()
+    assert lines[0] == "time,id,verdict,severity,attck,title,summary"
+    assert "kind,mac,ip,server_id,os,device,vendor,confidence" in lines
     _req(addr, "POST", "/api/session/stop", token="TESTTOKEN", body={}, origin=o)
 
 

--- a/tests/unit/test_web.py
+++ b/tests/unit/test_web.py
@@ -152,9 +152,10 @@ def test_report_download_csv(server):
     assert r.status == 200
     assert r.getheader("Content-Type") == "text/csv"
     assert "attachment" in (r.getheader("Content-Disposition") or "")
-    lines = body.splitlines()
-    assert lines[0] == "time,id,verdict,severity,attck,title,summary"
-    assert "kind,mac,ip,server_id,os,device,vendor,confidence" in lines
+    assert body.splitlines()[0] == (
+        "section,time,id,verdict,severity,attck,title,summary,"
+        "kind,mac,ip,server_id,os,device,vendor,confidence"
+    )
     _req(addr, "POST", "/api/session/stop", token="TESTTOKEN", body={}, origin=o)
 
 


### PR DESCRIPTION
Four changes for running DHCPig as a lab exercise or scripted engagement, where the report goes to someone else and the result has to be machine-readable. All additive; nothing changes what goes on the wire.

### `--fail-on {fail,inconclusive,never}`

Exits `1` when a finding at that verdict or worse was raised, so a scoring script can branch on the outcome:

```sh
sudo dhcpig exhaust eth0 --report run.json --fail-on fail
[ $? -eq 1 ] && echo "segment is vulnerable"
```

Test for `1`, not for "non-zero" — `2`, `3` and `130` mean the run never completed. Default `never` keeps exit `0` meaning "the run worked"; a run that failed to execute keeps its own code.

### MITRE ATT&CK ids on findings

`Finding.attck`, from the catalogue in `core/findings.py`, rendered in all three report formats: `T1498` for the pool-drain findings, `T1557.003` for speaking DHCP for another device, `T1557.002` for the forged-ARP eviction chain, `T1018` for the neighbour inventory.

It marks the technique a finding **assesses**, not a claim it worked — so `DHCP_STARVATION_NOT_ATTAINED` (PASS) carries `T1498` just as the FAIL does, letting the report say "attempted, and held". Renderers always emit `attck` beside `verdict`. Controls, recovery, dry runs and `RUN_SUMMARY` stay unmapped. A test rejects unknown ids.

### The CSV export no longer drops the findings

It emitted the host inventory alone, losing every verdict the run produced. Both kinds now share one header, discriminated by a leading `section` column, findings first:

```
section,time,id,verdict,severity,attck,title,summary,kind,mac,ip,server_id,os,device,vendor,confidence
finding,2026-09-06T13:26:41+00:00,CLIENTS_EVICTED_FROM_ADDRESSES,FAIL,high,T1557.002,ARP-conflict eviction forced clients off their addresses,"evicted=2 | ...",,,,,,,,
inventory,,,,,,,,lease,de:ad:00:00:00:01,10.0.0.5,10.0.0.1,,,,
```

One header rather than two stacked ones: two suit a spreadsheet but trap every other reader — `csv.DictReader` doesn't fail on the second header, it shifts each inventory row left (MAC under `id`, IP under `verdict`) and returns plausible garbage. This is the one behaviour change to an existing output format.

### Timestamps for log correlation

Each `Finding` is stamped with `ts` when raised, not when the report is rendered; the header gains UTC `started_at_iso`/`ended_at_iso` beside the existing epoch floats. Shown per finding in the HTML report next to the technique.

## The four commits

1. **The feature** — the four changes above.
2. **Review fixes.** Two real bugs: `ended_at` was stamped at render time, so the web UI's render-on-download inflated the reported run window (now read from `SessionEnded`); and the CSV's original two stacked headers were the `DictReader` trap described above. Plus three smaller ones — the README example used `|| echo`, firing on exit 2/3/130; the ATT&CK "assesses, not achieved" contract was undocumented and read as a bug; and one new test was vacuous, comparing a loose `Finding` against an unrelated recorder without rendering anything.
3. **Prose only** — the reasoning above was over-explained across comments, docstrings and the CHANGELOG. No behaviour or coverage change.
4. **Test consolidation** — twelve new tests folded to three, one per feature, with the CSV and HTML assertions moved into the `test_render_csv`/`test_render_html` that already existed.

## Testing

- 414 unit tests pass (411 baseline + 3); `ruff check`, `ruff format --check`, `mypy src/dhcpig/core` clean; `man --warnings` clean. CI green on 3.11/3.12/3.13 + `build-check`.
- Verified through the real CLI, not only tests: a run raising a catalogued `FAIL` exits `1` under `--fail-on fail` and writes correct `.json`/`.csv`/`.html`; a real engine run confirms `ended_at` doesn't move across re-renders.
- Coverage of the consolidated tests verified by mutation: reverting `ended_at` to render time, the CSV to two stacked headers, `--fail-on` to ignoring its threshold, and a catalogue id to a typo each fail exactly one test.
- **Not run:** the integration test (`make integration`) needs root + Linux and is deselected by default. Untouched by this change, but nothing here has been exercised against a live network.

## Notes

- The web UI receives `attck` and `ts` on every finding but doesn't render them yet — additive, nothing breaks. Follow-up if you want parity with the HTML report.
- Docs: `README.md`, `packaging/dhcpig.1`, `CHANGELOG.md` under `## Unreleased`. No version bump — say the word if you'd rather this land as 2.7.4.
- `docs/DESIGN.md` untouched; no section numbers moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gxCeg19rebRCKGccPoq4m